### PR TITLE
TRON-82 - Remove address param from builder.sign()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/account-lib",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "BitGo's account library functions",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/src/coin/baseCoin/coin.ts
+++ b/src/coin/baseCoin/coin.ts
@@ -11,12 +11,14 @@ export interface BaseCoin {
   /**
    * Validate an address. Throws an exception if invalid.
    * @param address the address
-   * @param addressFormat the address format - this will be handled by the implementing coin as an enum
+   * @param addressFormat the address format - this will be handled by the implementing coin as an
+   *     enum
    */
   validateAddress(address: BaseAddress, addressFormat?: string);
 
   /***
-   * Validates the value corresponding to an amount can be used for this transaction. Throws an exception if invalid.
+   * Validates the value corresponding to an amount can be used for this transaction. Throws an
+   * exception if invalid.
    */
   validateValue(value: BigNumber);
 
@@ -40,8 +42,7 @@ export interface BaseCoin {
   /**
    * Sign a transaction. Creates and attaches a signature to this transaction.
    * @param privateKey the private key associated with this signing mechanism
-   * @param address the address we're signing from
    * @param transaction our txBuilder's transaction typically
    */
-  sign(privateKey: BaseKey, address: BaseAddress, transaction: BaseTransaction): BaseTransaction;
+  sign(privateKey: BaseKey, transaction: BaseTransaction): BaseTransaction;
 }

--- a/src/coin/trx/network/coin.ts
+++ b/src/coin/trx/network/coin.ts
@@ -84,7 +84,7 @@ export class TrxBase implements BaseCoin {
     return new Transaction(this._coinConfig, rawTransaction);
   }
 
-  public sign(privateKey: Key, address: Address, transaction: Transaction): Transaction {
+  public sign(privateKey: Key, transaction: Transaction): Transaction {
     if (!transaction.senders) {
       throw new SigningError('transaction has no sender');
     }

--- a/src/coin/trx/transaction.ts
+++ b/src/coin/trx/transaction.ts
@@ -6,6 +6,7 @@ import { ContractType} from "./enum";
 import BigNumber from "bignumber.js";
 import { ParseTransactionError } from "../baseCoin/errors";
 import { TransactionType } from "../baseCoin/enum";
+import {BaseKey} from "../baseCoin/iface";
 
 export class Transaction extends BaseTransaction {
   private _decodedRawDataHex: RawData;
@@ -50,6 +51,15 @@ export class Transaction extends BaseTransaction {
       default:
         throw new ParseTransactionError('Unsupported contract type');
     }
+  }
+
+  /**
+   * Tron transaction do not contain the owners account address so it is not possible to check the
+   * private key with any but the account main address. This is not enough to fail this check, so it
+   * is a no-op.
+   */
+  canSign(key: BaseKey): boolean {
+    return true;
   }
 
   toJson(): TransactionReceipt {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,4 +1,4 @@
-import { BaseAddress, Destination } from "./coin/baseCoin/iface";
+import {BaseAddress, BaseKey, Destination} from "./coin/baseCoin/iface";
 import { BaseCoin as CoinConfig } from "@bitgo/statics";
 import { TransactionType } from "./coin/baseCoin";
 
@@ -38,6 +38,15 @@ export abstract class BaseTransaction {
   get validTo(): number {
     return this._validTo;
   }
+
+  /**
+   * Whether the private key can sign this transaction in its current state or not. it is possible
+   * some transactions can only enforce this check after some other fields have been filled already
+   * or even during build time.
+   * @param key to verify permissions on
+   * @return false if the key cannot sign the transaction without a doubt, true otherwise
+   */
+  abstract canSign(key: BaseKey): boolean;
 
   abstract toJson(): any;
 }

--- a/src/transactionBuilder.ts
+++ b/src/transactionBuilder.ts
@@ -2,6 +2,7 @@ import { BaseCoin } from "./coin/baseCoin";
 import { BaseAddress, BaseKey } from "./coin/baseCoin/iface";
 import { CoinFactory } from "./coinFactory";
 import { BaseTransaction } from "./transaction";
+import {SigningError} from "./coin/baseCoin/errors";
 
 export interface TransactionBuilderParams {
   coinName: string;
@@ -34,14 +35,16 @@ export class TransactionBuilder {
 
   /**
    * Signs the transaction in our builder.
-   * @param key the key associated with this transaction
-   * @param fromAddress
+   * @param key one of the keys associated with this transaction
    */
-  sign(key: BaseKey, fromAddress: BaseAddress) {
-    this.coin.validateAddress(fromAddress);
+  sign(key: BaseKey) {
+    // Make sure the key is valid
     this.coin.validateKey(key);
+    if (!this.transaction.canSign(key)) {
+      throw new SigningError('Private key cannot sign the transaction');
+    }
 
-    this.transaction = this.coin.sign(key, fromAddress, this.transaction);
+    this.transaction = this.coin.sign(key, this.transaction);
   }
 
   /**

--- a/test/resources/testCoin.ts
+++ b/test/resources/testCoin.ts
@@ -33,7 +33,7 @@ export class TestCoin implements BaseCoin {
     return this._buildTransaction;
   }
 
-  public sign(privateKey: BaseKey, address: BaseAddress, transaction: BaseTransaction): BaseTransaction {
+  public sign(privateKey: BaseKey, transaction: BaseTransaction): BaseTransaction {
     return this._sign;
   }
 }

--- a/test/resources/testTransaction.ts
+++ b/test/resources/testTransaction.ts
@@ -1,0 +1,14 @@
+import {BaseTransaction} from "../../src/transaction";
+import {BaseKey} from "../../src/coin/baseCoin/iface";
+
+/**
+ * The purpose of this coin is to provide a mock to use for the test runner since there is no easy
+ * way to mock abstract methods with sinon.
+ */
+export class TestTransaction extends BaseTransaction {
+  canSign(key: BaseKey): boolean {
+    return true;
+  }
+
+  toJson(): any { }
+}

--- a/test/unit/coin/trx/trx.ts
+++ b/test/unit/coin/trx/trx.ts
@@ -42,20 +42,20 @@ describe('Tron test network', function() {
     it('should sign an unsigned tx', () => {
       const txJson = JSON.stringify(UnsignedBuildTransaction);
       txBuilder.from(txJson);
-      txBuilder.sign({ key: FirstPrivateKey }, { address: FirstExpectedKeyAddress });
+      txBuilder.sign({ key: FirstPrivateKey });
     });
 
     it('should sign an unsigned tx', () => {
       const txJson = JSON.stringify(FirstSigOnBuildTransaction);
       txBuilder.from(txJson);
-      txBuilder.sign({ key: SecondPrivateKey }, { address: SecondExpectedKeyAddress });
+      txBuilder.sign({ key: SecondPrivateKey });
     });
 
     it('should not duplicate an signed tx', (done) => {
       const txJson = JSON.stringify(FirstSigOnBuildTransaction);
       txBuilder.from(txJson);
       try {
-        txBuilder.sign({ key: FirstPrivateKey }, { address: FirstExpectedKeyAddress });
+        txBuilder.sign({ key: FirstPrivateKey });
         should.fail('didnt throw an error', 'throws an error');
       } catch {
         done();
@@ -71,7 +71,7 @@ describe('Tron test network', function() {
     it('should build an half signed tx', () => {
       const txJson = JSON.stringify(UnsignedBuildTransaction);
       txBuilder.from(txJson);
-      txBuilder.sign({ key: FirstPrivateKey }, { address: FirstExpectedKeyAddress });
+      txBuilder.sign({ key: FirstPrivateKey });
       const tx = txBuilder.build();
 
       tx.id.should.equal('80b8b9eaed51c8bba3b49f7f0e7cc5f21ac99a6f3e2893c663b544bf2c695b1d');
@@ -85,7 +85,7 @@ describe('Tron test network', function() {
 
     it('should sign a fully signed tx', () => {
       txBuilder.from(FirstSigOnBuildTransaction);
-      txBuilder.sign({ key: SecondPrivateKey }, { address: SecondExpectedKeyAddress });
+      txBuilder.sign({ key: SecondPrivateKey});
       const tx = txBuilder.build();
 
       tx.toJson().signature[0].should.equal('bd08e6cd876bb573dd00a32870b58b70ea8b7908f5131686502589941bfa4fdda76b8c81bbbcfc549be6d4988657cea122df7da46c72041def2683d6ecb04a7401');

--- a/test/unit/transactionBuilder.ts
+++ b/test/unit/transactionBuilder.ts
@@ -2,6 +2,8 @@ import { TransactionBuilder } from '../../src/';
 import { TestCoin } from '../resources/testCoin';
 import { CoinFactory } from "../../src/coinFactory";
 import sinon = require('sinon');
+import {TestTransaction} from "../resources/testTransaction";
+import * as should from 'should';
 
 describe('Transaction builder', () => {
   let txBuilder: TransactionBuilder;
@@ -26,10 +28,24 @@ describe('Transaction builder', () => {
   });
 
   it('should sign a transaction that is valid', () => {
-    txBuilder.from(null);
-    txBuilder.sign({ key: ''  }, { address: 'fakeAddress' });
+    let testTx = sinon.createStubInstance(TestTransaction);
+    testTx.canSign.returns(true);
+    testCoin.parseTransaction.returns(testTx);
 
-    sandbox.assert.calledOnce(testCoin.validateAddress);
+    txBuilder.from(null);
+    txBuilder.sign({ key: ''  });
+
+    sandbox.assert.calledOnce(testCoin.validateKey);
+  });
+
+  it('should sign a transaction with an invalid signature', () => {
+    let testTx = sinon.createStubInstance(TestTransaction);
+    testTx.canSign.returns(false);
+    testCoin.parseTransaction.returns(testTx);
+
+    txBuilder.from(null);
+    should.throws(() => txBuilder.sign({ key: ''  }));
+
     sandbox.assert.calledOnce(testCoin.validateKey);
   });
 


### PR DESCRIPTION
The address in the signing step is redundant. At the signing step, we should already have all the information needed in the transaction to verify it is valid.
This check can easily be replaced by deriving the public key and subsequent addresses from the private key anyway.