### PR TITLE
[TRON-81] Add utility to future date Tron transactions

### DIFF
--- a/src/coin/baseCoin/coin.ts
+++ b/src/coin/baseCoin/coin.ts
@@ -45,4 +45,11 @@ export interface BaseCoin {
    * @param transaction our txBuilder's transaction typically
    */
   sign(privateKey: BaseKey, transaction: BaseTransaction): BaseTransaction;
+
+  /**
+   * Extends transaction's expiration date by the given number of milliseconds
+   * @param transaction The transaction to update
+   * @param extensionMs The number of milliseconds to extend the expiration by
+   */
+  extendTransaction(transaction: BaseTransaction, extensionMs: number): BaseTransaction;
 }

--- a/src/coin/baseCoin/errors.ts
+++ b/src/coin/baseCoin/errors.ts
@@ -9,11 +9,11 @@ export class ExtendableError extends Error {
     this.name = this.constructor.name;
     if (typeof Error.captureStackTrace === 'function') {
       Error.captureStackTrace(this, this.constructor);
-    } else { 
-      this.stack = (new Error(message)).stack; 
+    } else {
+      this.stack = (new Error(message)).stack;
     }
   }
-}  
+}
 
 export class ParseTransactionError extends ExtendableError {
   constructor(message: string) {
@@ -44,3 +44,10 @@ export class UtilsError extends ExtendableError {
     super(message);
   }
 }
+
+export class ExtendTransactionError extends ExtendableError {
+  constructor(message: string) {
+    super(message);
+  }
+}
+

--- a/src/coin/trx/network/coin.ts
+++ b/src/coin/trx/network/coin.ts
@@ -72,6 +72,16 @@ export class TrxBase implements BaseCoin {
   }
 
   /**
+   * Extends transaction's expiration date by the given number of milliseconds
+   * @param transaction The transaction to update
+   * @param extensionMs The number of milliseconds to extend the expiration by
+   */
+  public extendTransaction(transaction: Transaction, extensionMs: number): Transaction {
+    transaction.extendExpiration(extensionMs);
+    return transaction;
+  }
+
+  /**
    * Parse transaction takes in raw JSON directly from the node.
    * @param rawTransaction The Tron transaction in JSON format as returned by the Tron lib or a
    *     stringifyed version of such JSON.

--- a/src/coin/trx/utils.ts
+++ b/src/coin/trx/utils.ts
@@ -1,8 +1,16 @@
+const crypto = require('crypto');
 const tronweb = require('tronweb');
 import { protocol } from '../../../resources/trx/protobuf/tron';
 
 import * as assert from 'assert';
-import { TransferContract, RawData, AccountPermissionUpdateContract, Account, TransactionReceipt, Permission } from './iface';
+import {
+  TransferContract,
+  RawData,
+  AccountPermissionUpdateContract,
+  Account,
+  TransactionReceipt,
+  Permission,
+} from './iface';
 import { ContractType, PermissionType } from './enum';
 import { UtilsError } from '../baseCoin/errors';
 
@@ -85,7 +93,7 @@ export function getRawAddressFromPubKey(pubBytes: ByteArray | string): ByteArray
 }
 
 /**
- * Decodes a base64 encoded transaction in its protobuf representation.
+ * Decodes a hex encoded transaction in its protobuf representation.
  * @param hexString raw_data_hex field from tron transactions
  */
 export function decodeTransaction(hexString: string): RawData {

--- a/src/transactionBuilder.ts
+++ b/src/transactionBuilder.ts
@@ -56,4 +56,12 @@ export class TransactionBuilder {
     this.transaction = this.coin.buildTransaction(this.transaction);
     return this.transaction;
   }
+
+  /**
+   * Extend the validity of this transaction by the given amount of time
+   * @param extensionMs The number of milliseconds to extend the validTo time
+   */
+  extendValidTo(extensionMs: number) {
+    this.transaction = this.coin.extendTransaction(this.transaction, extensionMs);
+  }
 }

--- a/test/resources/testCoin.ts
+++ b/test/resources/testCoin.ts
@@ -11,6 +11,7 @@ import { BaseTransaction } from "../../src/transaction";
 export class TestCoin implements BaseCoin {
   _parseTransaction: BaseTransaction;
   _buildTransaction: BaseTransaction;
+  _extendTransaction: BaseTransaction;
   _sign: BaseTransaction;
 
   public displayName(): string {
@@ -31,6 +32,10 @@ export class TestCoin implements BaseCoin {
 
   public buildTransaction(transaction: BaseTransaction): BaseTransaction {
     return this._buildTransaction;
+  }
+
+  public extendTransaction(transaction: BaseTransaction, extensionMs: number): BaseTransaction {
+    return this._extendTransaction;
   }
 
   public sign(privateKey: BaseKey, transaction: BaseTransaction): BaseTransaction {

--- a/test/unit/coin/trx/trx.ts
+++ b/test/unit/coin/trx/trx.ts
@@ -114,4 +114,37 @@ describe('Tron test network', function() {
       tx.validTo.should.equal(1571811468000);
     });
   });
+
+  describe('Transaction extend', () => {
+    beforeEach(() => {
+      txBuilder = new TransactionBuilder({ coinName: 'ttrx '});
+    });
+
+    it('should not extend a half signed tx', () => {
+      const txJson = JSON.stringify(UnsignedBuildTransaction);
+      txBuilder.from(txJson);
+      txBuilder.sign({ key: FirstPrivateKey });
+
+      should.throws(() => txBuilder.extendValidTo(10000));
+    });
+
+    it('should extend an unsigned tx', () => {
+      const extendMs = 10000;
+      txBuilder.from(JSON.parse(JSON.stringify(UnsignedBuildTransaction)));
+      txBuilder.extendValidTo(extendMs);
+      const tx = txBuilder.build();
+
+      tx.id.should.not.equal(UnsignedBuildTransaction.txID);
+      tx.id.should.equal('764aa8a72c2c720a6556def77d6092f729b6e14209d8130f1692d5aff13f2503');
+      const oldExpiration = UnsignedBuildTransaction.raw_data.expiration;
+      tx.validTo.should.equal(oldExpiration + extendMs);
+      tx.type.should.equal(TransactionType.Send);
+      tx.senders.length.should.equal(1);
+      tx.senders[0].address.should.equal('TTsGwnTLQ4eryFJpDvJSfuGQxPXRCjXvZz');
+      tx.destinations.length.should.equal(1);
+      tx.destinations[0].address.should.equal('TNYssiPgaf9XYz3urBUqr861Tfqxvko47B');
+      tx.destinations[0].value.toString().should.equal('1718');
+      tx.validFrom.should.equal(1571811410819);
+    });
+  });
 });

--- a/test/unit/transactionBuilder.ts
+++ b/test/unit/transactionBuilder.ts
@@ -55,4 +55,13 @@ describe('Transaction builder', () => {
 
     sandbox.assert.calledOnce(testCoin.buildTransaction);
   });
+
+  it('should extend a transaction validTo field', () => {
+    txBuilder.from(null);
+    txBuilder.extendValidTo(10000);
+    txBuilder.build();
+
+    sandbox.assert.calledOnce(testCoin.extendTransaction);
+    sandbox.assert.calledOnce(testCoin.buildTransaction);
+  });
 });


### PR DESCRIPTION
The function deserializes tx hex, updates the expiration date, and
reserializes the tx hex.

I was able to send a successful extended multisig transaction using this code in coins-sandbox:
```
   ... normal send stuff

    const future_date_amount_ms = 4000;
    tx.raw_data.expiration = tx.raw_data.expiration += future_date_amount_ms;
    const updatedTxHex = bitgoAccountLib.Trx.Utils.extendTransaction(tx.raw_data_hex, future_date_amount_ms);
    tx.raw_data_hex = updatedTxHex; 
    tx.txID = calculateTxid(tx);

   ... signature, signature, send

```