### PR TITLE
Tron 95

### DIFF
--- a/src/coin/trx/iface.ts
+++ b/src/coin/trx/iface.ts
@@ -33,14 +33,22 @@ export interface RawData {
   expiration: number;
   timestamp: number;
   contractType: ContractType;
-  contract: TransferContract | AccountPermissionUpdateContract;
+  contract: TransferContract[] | AccountPermissionUpdateContract[];
+}
+
+export interface Value {
+  value: ValueFields
+}
+
+export interface ValueFields {
+  amount: number;
+  // base58 encoded addresses
+  owner_address: string;
+  to_address: string;
 }
 
 export interface TransferContract {
-  amount: number;
-  // base58 encoded addresses
-  toAddress: string;
-  ownerAddress: string;
+  parameter: Value
 }
 
 export interface AccountPermissionUpdateContract {

--- a/src/coin/trx/iface.ts
+++ b/src/coin/trx/iface.ts
@@ -48,7 +48,7 @@ export interface ValueFields {
 }
 
 export interface TransferContract {
-  parameter: Value
+  parameter: Value;
 }
 
 export interface AccountPermissionUpdateContract {

--- a/src/coin/trx/network/coin.ts
+++ b/src/coin/trx/network/coin.ts
@@ -77,8 +77,9 @@ export class TrxBase implements BaseCoin {
    *     stringifyed version of such JSON.
    */
   public parseTransaction(rawTransaction: TransactionReceipt | string): Transaction {
+    // TODO: add checks to ensure the raw_data, raw_data_hex, and txID are from the same transaction
     if (typeof rawTransaction === 'string') {
-      const transaction = this.createTransactionReceipt(rawTransaction);
+      const transaction = JSON.parse(rawTransaction);
       return new Transaction(this._coinConfig, transaction);
     }
     return new Transaction(this._coinConfig, rawTransaction);

--- a/src/coin/trx/transaction.ts
+++ b/src/coin/trx/transaction.ts
@@ -5,7 +5,7 @@ import { decodeTransaction } from "./utils";
 import { ContractType} from "./enum";
 import BigNumber from "bignumber.js";
 import { ParseTransactionError } from "../baseCoin/errors";
-import { TransactionType } from "../baseCoin/enum";
+import { TransactionType } from "../baseCoin/";
 import {BaseKey} from "../baseCoin/iface";
 
 export class Transaction extends BaseTransaction {
@@ -22,7 +22,7 @@ export class Transaction extends BaseTransaction {
       this._transaction = rawTransaction;
       this._decodedRawDataHex = decodeTransaction(rawTransaction.raw_data_hex);
       const senderAddress = {
-        address: this._decodedRawDataHex.contract.ownerAddress
+        address: (this._decodedRawDataHex.contract[0] as TransferContract).parameter.value.owner_address
       };
       this._fromAddresses = [senderAddress];
 
@@ -43,8 +43,8 @@ export class Transaction extends BaseTransaction {
       case ContractType.Transfer:
         this._type = TransactionType.Send;
         const destination = {
-          address: (rawData.contract as TransferContract).toAddress,
-          value: new BigNumber((rawData.contract as TransferContract).amount),
+          address: (rawData.contract[0] as TransferContract).parameter.value.to_address,
+          value: new BigNumber((rawData.contract[0] as TransferContract).parameter.value.amount),
         };
         this._destination = [destination];
         break;

--- a/src/coin/trx/utils.ts
+++ b/src/coin/trx/utils.ts
@@ -132,14 +132,14 @@ export function decodeRawTransaction(hexString: string): { expiration: number, t
   let raw;
   try {
     // we need to decode our raw_data_hex field first
-    raw = protocol.Transaction.raw.decode(bytes).toJSON();
+    raw = protocol.Transaction.raw.decode(bytes);
   } catch (e) {
     throw new UtilsError('There was an error decoding the initial raw_data_hex from the serialized tx.');
   }
 
   return {
-    expiration: raw.expiration,
-    timestamp: raw.timestamp,
+    expiration: Number(raw.expiration),
+    timestamp: Number(raw.timestamp),
     contracts: raw.contract,
   };
 }
@@ -160,7 +160,7 @@ export function decodeTransferContract(transferHex: string): TransferContract[] 
   let transferContract;
 
   try {
-    transferContract = protocol.TransferContract.decode(contractBytes).toJSON();
+    transferContract = protocol.TransferContract.decode(contractBytes);
   } catch (e) {
     throw new UtilsError('There was an error decoding the transfer contract in the transaction.');
   }

--- a/src/coin/trx/utils.ts
+++ b/src/coin/trx/utils.ts
@@ -114,7 +114,7 @@ export function decodeTransaction(hexString: string): RawData {
 
   return {
     contractType,
-    contract: contract,
+    contract,
     expiration: rawTransaction.expiration,
     timestamp: rawTransaction.timestamp,
   };

--- a/src/coin/trx/utils.ts
+++ b/src/coin/trx/utils.ts
@@ -185,7 +185,7 @@ export function decodeTransferContract(transferHex: string): TransferContract[] 
   return [{
     parameter: {
       value: {
-        amount,
+        amount: Number(amount),
         owner_address,
         to_address,
       }

--- a/src/coin/trx/utils.ts
+++ b/src/coin/trx/utils.ts
@@ -96,7 +96,7 @@ export function decodeTransaction(hexString: string): RawData {
     throw new UtilsError('Number of contracts is greater than 1.');
   }
 
-  let contract: TransferContract | AccountPermissionUpdateContract;
+  let contract: TransferContract[] | AccountPermissionUpdateContract[];
   let contractType: ContractType;
   // ensure the contract type is supported
   switch  (rawTransaction.contracts[0].parameter.type_url) {
@@ -114,7 +114,7 @@ export function decodeTransaction(hexString: string): RawData {
 
   return {
     contractType,
-    contract,
+    contract: contract,
     expiration: rawTransaction.expiration,
     timestamp: rawTransaction.timestamp,
   };
@@ -155,7 +155,7 @@ export function isValidHex(hex: string): Boolean {
 /** Deserialize the segment of the txHex which corresponds with the details of the transfer
  * @param transferHex is the value property of the "parameter" field of contractList[0]
  * */
-export function decodeTransferContract(transferHex: string): TransferContract {
+export function decodeTransferContract(transferHex: string): TransferContract[] {
   const contractBytes = Buffer.from(transferHex, 'base64');
   let transferContract;
 
@@ -178,15 +178,19 @@ export function decodeTransferContract(transferHex: string): TransferContract {
   }
 
   // deserialize attributes
-  const ownerAddress = getBase58AddressFromByteArray(getByteArrayFromHexAddress(Buffer.from(transferContract.ownerAddress, 'base64').toString('hex')));
-  const toAddress = getBase58AddressFromByteArray(getByteArrayFromHexAddress(Buffer.from(transferContract.toAddress, 'base64').toString('hex')));
+  const owner_address = getBase58AddressFromByteArray(getByteArrayFromHexAddress(Buffer.from(transferContract.ownerAddress, 'base64').toString('hex')));
+  const to_address = getBase58AddressFromByteArray(getByteArrayFromHexAddress(Buffer.from(transferContract.toAddress, 'base64').toString('hex')));
   const amount = transferContract.amount;
 
-  return {
-    toAddress,
-    ownerAddress,
-    amount,
-  };
+  return [{
+    parameter: {
+      value: {
+        amount,
+        owner_address,
+        to_address,
+      }
+    }
+  }];
 }
 
 /**

--- a/test/resources/trx.ts
+++ b/test/resources/trx.ts
@@ -9,18 +9,22 @@ export const SecondExpectedKeyAddress = 'TDzm1tCXM2YS1PDa3GoXSvxdy4AgwVbBPE';
 export const FirstExpectedSig = 'bd08e6cd876bb573dd00a32870b58b70ea8b7908f5131686502589941bfa4fdda76b8c81bbbcfc549be6d4988657cea122df7da46c72041def2683d6ecb04a7401';
 export const SecondExpectedSig = 'f3cabe2f4aed13e2342c78c7bf4626ea36cd6509a44418c24866814d3426703686be9ef21bd993324c520565beee820201f2a50a9ac971732410d3eb69cdb2a600';
 
-export const UnsignedBuildTransaction = { 
+export const UnsignedBuildTransaction = {
   visible: false,
   txID:
      '80b8b9eaed51c8bba3b49f7f0e7cc5f21ac99a6f3e2893c663b544bf2c695b1d',
   raw_data:
      { contract:
         [ { parameter:
-           { value:
-              { amount: 1718,
-                 owner_address: '41c4530f6bfa902b7398ac773da56106a15af15f92',
-                 to_address: '4189ffaf9da8c6fae32189b2e6dce228249b1129aa' },
-              type_url: 'type.googleapis.com/protocol.TransferContract' },
+           {
+             value:
+             {
+                amount: 1718,
+                owner_address: '41c4530f6bfa902b7398ac773da56106a15af15f92',
+                to_address: '4189ffaf9da8c6fae32189b2e6dce228249b1129aa'
+              },
+              type_url: 'type.googleapis.com/protocol.TransferContract'
+           },
            type: 'TransferContract' } ],
      ref_block_bytes: '90e4',
      ref_block_hash: 'a018bf9892ddb138',
@@ -28,17 +32,17 @@ export const UnsignedBuildTransaction = {
      timestamp: 1571811410819 },
   raw_data_hex:
      '0a0290e42208a018bf9892ddb13840e0c58ebadf2d5a66080112620a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412310a1541c4530f6bfa902b7398ac773da56106a15af15f9212154189ffaf9da8c6fae32189b2e6dce228249b1129aa18b60d7083878bbadf2d',
-   
+
 };
 
-export const FirstSigOnBuildTransaction = (() => { 
+export const FirstSigOnBuildTransaction = (() => {
   let modifiedBuild = JSON.parse(JSON.stringify(UnsignedBuildTransaction));
   modifiedBuild["signature"] = [];
   modifiedBuild["signature"].push('bd08e6cd876bb573dd00a32870b58b70ea8b7908f5131686502589941bfa4fdda76b8c81bbbcfc549be6d4988657cea122df7da46c72041def2683d6ecb04a7401');
   return modifiedBuild;
 })();
 
-export const SecondSigOnBuildTransaction = (() => { 
+export const SecondSigOnBuildTransaction = (() => {
   let modifiedBuild = JSON.parse(JSON.stringify(UnsignedBuildTransaction));;
   modifiedBuild["signature"] = [];
   modifiedBuild["signature"].push('f3cabe2f4aed13e2342c78c7bf4626ea36cd6509a44418c24866814d3426703686be9ef21bd993324c520565beee820201f2a50a9ac971732410d3eb69cdb2a600');

--- a/test/unit/coin/trx/trx.ts
+++ b/test/unit/coin/trx/trx.ts
@@ -90,7 +90,7 @@ describe('Tron test network', function() {
 
       signedTxJson.txID.should.equal(UnsignedBuildTransaction.txID);
       signedTxJson.raw_data_hex.should.equal(UnsignedBuildTransaction.raw_data_hex);
-      (JSON.stringify(signedTxJson.raw_data) === JSON.stringify(UnsignedBuildTransaction.raw_data)).should.be.ok
+      (JSON.stringify(signedTxJson.raw_data) === JSON.stringify(UnsignedBuildTransaction.raw_data)).should.be.ok;
       signedTxJson.signature.length.should.equal(1);
       signedTxJson.signature[0].should.equal('bd08e6cd876bb573dd00a32870b58b70ea8b7908f5131686502589941bfa4fdda76b8c81bbbcfc549be6d4988657cea122df7da46c72041def2683d6ecb04a7401');
     });

--- a/test/unit/coin/trx/trx.ts
+++ b/test/unit/coin/trx/trx.ts
@@ -81,6 +81,20 @@ describe('Tron test network', function() {
       tx.destinations[0].value.toString().should.equal('1718');
     });
 
+    it('should build the right JSON after is half signed tx', () => {
+      const txJson = JSON.stringify(UnsignedBuildTransaction);
+      txBuilder.from(txJson);
+      txBuilder.sign({ key: FirstPrivateKey });
+      const tx = txBuilder.build();
+      const signedTxJson = tx.toJson();
+
+      signedTxJson.txID.should.equal(UnsignedBuildTransaction.txID);
+      signedTxJson.raw_data_hex.should.equal(UnsignedBuildTransaction.raw_data_hex);
+      (JSON.stringify(signedTxJson.raw_data) === JSON.stringify(UnsignedBuildTransaction.raw_data)).should.be.ok
+      signedTxJson.signature.length.should.equal(1);
+      signedTxJson.signature[0].should.equal('bd08e6cd876bb573dd00a32870b58b70ea8b7908f5131686502589941bfa4fdda76b8c81bbbcfc549be6d4988657cea122df7da46c72041def2683d6ecb04a7401');
+    });
+
     it('should sign a fully signed tx', () => {
       txBuilder.from(FirstSigOnBuildTransaction);
       txBuilder.sign({ key: SecondPrivateKey});

--- a/test/unit/coin/trx/util.ts
+++ b/test/unit/coin/trx/util.ts
@@ -114,15 +114,15 @@ describe('Util library should', function() {
     const tx = UnsignedTransferContractTx.tx;
     const rawTx = Utils.decodeRawTransaction(tx.raw_data_hex);
     const value = UnsignedTransferContractTx.tx.raw_data.contract[0].parameter.value;
-    const parsedTx = Utils.decodeTransferContract(rawTx.contracts[0].parameter.value) as TransferContract;
+    const parsedContract = Utils.decodeTransferContract(rawTx.contracts[0].parameter.value) as TransferContract[];
 
     const toAddress = Utils.getBase58AddressFromHex(value.to_address);
     const ownerAddress = Utils.getBase58AddressFromHex(value.owner_address);
     const amount = value.amount;
 
-    should.equal(parsedTx.toAddress, toAddress);
-    should.equal(parsedTx.ownerAddress, ownerAddress);
-    should.equal(parsedTx.amount, amount);
+    should.equal(parsedContract[0].parameter.value.to_address, toAddress);
+    should.equal(parsedContract[0].parameter.value.owner_address, ownerAddress);
+    should.equal(parsedContract[0].parameter.value.amount, amount);
   });
 
    it('should decode an AccountPermissionUpdate Contract', () => {


### PR DESCRIPTION
The `transaction.toJSON()` method was returning an invalid transaction, aka, a transaction that could not be broadcasted to the network due to discrepancies in the format.