### PR TITLE
Udpate version and fix dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/account-lib",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "BitGo's account library functions",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -35,6 +35,7 @@
     "@bitgo/statics": "^2.4.0-rc.0",
     "bignumber.js": "^9.0.0",
     "bitgo-utxo-lib": "^1.6.0",
+    "protobufjs": "^6.8.8",
     "tronweb": "^2.7.2"
   },
   "devDependencies": {
@@ -54,7 +55,6 @@
     "mochawesome": "^4.1.0",
     "nyc": "^14.0.0",
     "prettier": "^1.19.1",
-    "protobufjs": "^6.8.8",
     "should": "^13.1.3",
     "sinon": "^7.5.0",
     "terser-webpack-plugin": "^1.2.3",


### PR DESCRIPTION
Turns out we need `protobufjs` as a main dependency.

Bumping the version number to prepare us for a new alpha release