### PR TITLE
Use inputs and outputs nomenclature

### DIFF
--- a/src/coin/baseCoin/baseTransaction.ts
+++ b/src/coin/baseCoin/baseTransaction.ts
@@ -1,4 +1,4 @@
-import { BaseAddress, BaseKey, Destination } from './iface';
+import { BaseKey, Entry } from './iface';
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
 import { TransactionType } from './enum';
 
@@ -7,8 +7,8 @@ import { TransactionType } from './enum';
  */
 export abstract class BaseTransaction {
   protected _id: string; // The transaction id as seen in the blockchain
-  protected _fromAddresses: BaseAddress[];
-  protected _destination: Destination[];
+  protected _inputs: Entry[];
+  protected _outputs: Entry[];
   protected _type: TransactionType;
 
   /**
@@ -25,12 +25,12 @@ export abstract class BaseTransaction {
     return this._type;
   }
 
-  get destinations(): Destination[] {
-    return this._destination;
+  get outputs(): Entry[] {
+    return this._outputs;
   }
 
-  get senders(): BaseAddress[] {
-    return this._fromAddresses;
+  get inputs(): Entry[] {
+    return this._inputs;
   }
 
   /**

--- a/src/coin/baseCoin/iface.ts
+++ b/src/coin/baseCoin/iface.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 
 export interface BaseAddress {
-  address: any;
+  address: string;
 }
 
 export interface BaseKey {

--- a/src/coin/baseCoin/iface.ts
+++ b/src/coin/baseCoin/iface.ts
@@ -24,6 +24,6 @@ export type ExtendedKeys = {
   xpub: string;
 }
 
-export interface Destination extends BaseAddress {
+export interface Entry extends BaseAddress {
   value: BigNumber;
 }

--- a/src/coin/trx/transaction.ts
+++ b/src/coin/trx/transaction.ts
@@ -134,6 +134,9 @@ export class Transaction extends BaseTransaction {
     }
   }
 
+  /**
+   * Get the signatures associated with this transaction.
+   */
   get signature(): string[] {
     if (!this._transaction) {
       throw new ParseTransactionError('Empty transaction');

--- a/src/coin/trx/transaction.ts
+++ b/src/coin/trx/transaction.ts
@@ -48,33 +48,37 @@ export class Transaction extends BaseTransaction {
     this._validFrom = rawData.timestamp;
     this._validTo = rawData.expiration;
 
-    let destination, senderAddress;
+    let output, input;
     // Contract-specific fields
     switch (rawData.contractType) {
       case ContractType.Transfer:
         this._type = TransactionType.Send;
-        destination = {
+        const value = new BigNumber((rawData.contract[0] as TransferContract).parameter.value.amount);
+        output = {
           address: (rawData.contract[0] as TransferContract).parameter.value.to_address,
-          value: new BigNumber((rawData.contract[0] as TransferContract).parameter.value.amount),
+          value,
         };
-        senderAddress = {
+        input = {
           address: (rawData.contract[0] as TransferContract).parameter.value.owner_address,
+          value,
         };
         break;
       case ContractType.AccountPermissionUpdate:
-        destination = {
+        this._type = TransactionType.WalletInitialization;
+        output = {
           address: (rawData.contract as any).owner_address,
           value: new BigNumber(0),
         };
-        senderAddress = {
+        input = {
           address: (rawData.contract as any).owner_address,
+          value: new BigNumber(0),
         };
         break;
       default:
         throw new ParseTransactionError('Unsupported contract type');
     }
-    this._fromAddresses = [senderAddress];
-    this._destination = [destination];
+    this._inputs = [input];
+    this._outputs = [output];
   }
 
   /**
@@ -128,6 +132,16 @@ export class Transaction extends BaseTransaction {
     } catch (e) {
       throw new ExtendTransactionError('There was an error decoding the initial raw_data_hex from the serialized tx.');
     }
+  }
+
+  get signature(): string[] {
+    if (!this._transaction) {
+      throw new ParseTransactionError('Empty transaction');
+    }
+    if (this._transaction.signature) {
+      return this._transaction.signature;
+    }
+    return [];
   }
 
   get validFrom(): number {

--- a/src/coin/trx/transactionBuilder.ts
+++ b/src/coin/trx/transactionBuilder.ts
@@ -42,11 +42,11 @@ export class TransactionBuilder extends BaseTransactionBuilder {
    * Tron transaction signing implementation.
    */
   protected signImplementation(key: BaseKey): Transaction {
-    if (!this.transaction.senders) {
+    if (!this.transaction.inputs) {
       throw new SigningError('transaction has no sender');
     }
 
-    if (!this.transaction.destinations) {
+    if (!this.transaction.outputs) {
       throw new SigningError('transaction has no receiver');
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import { coins } from '@bitgo/statics';
 import { BuildTransactionError } from './coin/baseCoin/errors';
 
+import * as crypto from './utils/crypto'
+export { crypto };
 // coins
 import * as BaseCoin from './coin/baseCoin';
 export { BaseCoin };

--- a/test/unit/coin/trx/transaction.ts
+++ b/test/unit/coin/trx/transaction.ts
@@ -1,0 +1,37 @@
+import * as should from 'should';
+import { coins } from '@bitgo/statics';
+import {UnsignedBuildTransaction} from "../../../resources/trx";
+import {Transaction} from "../../../../src/coin/trx";
+import {TransactionReceipt} from "../../../../src/coin/trx/iface";
+
+describe('Tron transactions', function() {
+  describe('should parse', () => {
+    it('inputs and outputs from an unsigned transaction', () => {
+      // @ts-ignore
+      const tx = new Transaction(coins.get('ttrx'), UnsignedBuildTransaction as TransactionReceipt);
+      tx.inputs.length.should.equal(1);
+      tx.inputs[0].address.should.equal('TTsGwnTLQ4eryFJpDvJSfuGQxPXRCjXvZz');
+      tx.inputs[0].value.toString().should.equal('1718');
+      tx.outputs.length.should.equal(1);
+      tx.outputs[0].address.should.equal('TNYssiPgaf9XYz3urBUqr861Tfqxvko47B');
+      tx.outputs[0].value.toString().should.equal('1718');
+    });
+  });
+
+  describe('should throw when', () => {
+    it('transaction is empty and toJson is called', () => {
+      const tx = new Transaction(coins.get('ttrx'));
+      should.throws(() => tx.toJson());
+    });
+
+    it('transaction is empty and extendExpiration is called', () => {
+      const tx = new Transaction(coins.get('ttrx'));
+      should.throws(() => tx.extendExpiration(1));
+    });
+
+    it('the extension time is negative', () => {
+      const tx = new Transaction(coins.get('ttrx'));
+      should.throws(() => tx.extendExpiration(-1));
+    });
+  });
+});

--- a/test/unit/coin/trx/transactionBuilder.ts
+++ b/test/unit/coin/trx/transactionBuilder.ts
@@ -67,11 +67,12 @@ describe('Tron', function() {
 
         tx.id.should.equal('80b8b9eaed51c8bba3b49f7f0e7cc5f21ac99a6f3e2893c663b544bf2c695b1d');
         tx.type.should.equal(TransactionType.Send);
-        tx.senders.length.should.equal(1);
-        tx.senders[0].address.should.equal('TTsGwnTLQ4eryFJpDvJSfuGQxPXRCjXvZz');
-        tx.destinations.length.should.equal(1);
-        tx.destinations[0].address.should.equal('TNYssiPgaf9XYz3urBUqr861Tfqxvko47B');
-        tx.destinations[0].value.toString().should.equal('1718');
+        tx.inputs.length.should.equal(1);
+        tx.inputs[0].address.should.equal('TTsGwnTLQ4eryFJpDvJSfuGQxPXRCjXvZz');
+        tx.inputs[0].value.toString().should.equal('1718');
+        tx.outputs.length.should.equal(1);
+        tx.outputs[0].address.should.equal('TNYssiPgaf9XYz3urBUqr861Tfqxvko47B');
+        tx.outputs[0].value.toString().should.equal('1718');
         tx.validFrom.should.equal(1571811410819);
         tx.validTo.should.equal(1571811468000);
       });
@@ -113,11 +114,12 @@ describe('Tron', function() {
 
       tx.id.should.equal('80b8b9eaed51c8bba3b49f7f0e7cc5f21ac99a6f3e2893c663b544bf2c695b1d');
       tx.type.should.equal(TransactionType.Send);
-      tx.senders.length.should.equal(1);
-      tx.senders[0].address.should.equal('TTsGwnTLQ4eryFJpDvJSfuGQxPXRCjXvZz');
-      tx.destinations.length.should.equal(1);
-      tx.destinations[0].address.should.equal('TNYssiPgaf9XYz3urBUqr861Tfqxvko47B');
-      tx.destinations[0].value.toString().should.equal('1718');
+      tx.inputs.length.should.equal(1);
+      tx.inputs[0].address.should.equal('TTsGwnTLQ4eryFJpDvJSfuGQxPXRCjXvZz');
+      tx.inputs[0].value.toString().should.equal('1718');
+      tx.outputs.length.should.equal(1);
+      tx.outputs[0].address.should.equal('TNYssiPgaf9XYz3urBUqr861Tfqxvko47B');
+      tx.outputs[0].value.toString().should.equal('1718');
     });
 
     it('should build the right JSON after is half signed tx', () => {
@@ -153,11 +155,12 @@ describe('Tron', function() {
       const oldExpiration = UnsignedBuildTransaction.raw_data.expiration;
       tx.validTo.should.equal(oldExpiration + extendMs);
       tx.type.should.equal(TransactionType.Send);
-      tx.senders.length.should.equal(1);
-      tx.senders[0].address.should.equal('TTsGwnTLQ4eryFJpDvJSfuGQxPXRCjXvZz');
-      tx.destinations.length.should.equal(1);
-      tx.destinations[0].address.should.equal('TNYssiPgaf9XYz3urBUqr861Tfqxvko47B');
-      tx.destinations[0].value.toString().should.equal('1718');
+      tx.inputs.length.should.equal(1);
+      tx.inputs[0].address.should.equal('TTsGwnTLQ4eryFJpDvJSfuGQxPXRCjXvZz');
+      tx.inputs[0].value.toString().should.equal('1718');
+      tx.outputs.length.should.equal(1);
+      tx.outputs[0].address.should.equal('TNYssiPgaf9XYz3urBUqr861Tfqxvko47B');
+      tx.outputs[0].value.toString().should.equal('1718');
       tx.validFrom.should.equal(1571811410819);
     });
   });


### PR DESCRIPTION
Destination and sender is not a good name. Inputs and outputs are easier to understand. It also makes it easier to consume by library users.