### PR TITLE
Fix terminology of raw private keys

### DIFF
--- a/src/coin/trx/iface.ts
+++ b/src/coin/trx/iface.ts
@@ -1,14 +1,14 @@
 import { ContractType, PermissionType } from './enum';
 
 /**
- * A Tron private key in extended or compressed format
+ * A Tron private key in extended or raw format
  */
 export type PrivateKey = {
   prv: string
 }
 
 /**
- * A Tron public key in extended, compressed, or uncompressed
+ * A Tron public key in extended, compressed, or uncompressed format
  */
 export type PublicKey = {
   pub: string

--- a/src/coin/trx/keyPair.ts
+++ b/src/coin/trx/keyPair.ts
@@ -20,7 +20,7 @@ export class KeyPair {
   /**
    * Public constructor. By default, creates a key pair with a random master seed.
    *
-   * @param source Either a master seed, a private key (extended or compressed), or a public key
+   * @param source Either a master seed, a private key (extended or raw), or a public key
    *     (extended, compressed, or uncompressed)
    */
   constructor(source?: KeyPairOptions) {
@@ -45,7 +45,7 @@ export class KeyPair {
   /**
    * Build a Hierarchical Deterministic node or an ECPair from a private key.
    *
-   * @param prv An extended or compressed private key
+   * @param prv An extended or raw private key
    */
   private recordKeysFromPrivateKey(prv: string): void {
     if (Crypto.isValidXprv(prv)) {
@@ -61,7 +61,7 @@ export class KeyPair {
   /**
    * Build a Hierarchical Deterministic node or an ECPair from a public key.
    *
-   * @param pub An extended, compressed, or uncompressed public key
+   * @param {String} pub - An extended, compressed, or uncompressed public key
    */
   private recordKeysFromPublicKey(pub: string): void {
     if (Crypto.isValidXpub(pub)) {
@@ -75,7 +75,7 @@ export class KeyPair {
   }
 
   /**
-   * Tron default keys format is compressed private and uncompressed public key
+   * Tron default keys format is raw private and uncompressed public key
    * @return The keys in the protocol default key format
    */
   getKeys(): DefaultKeys {

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -2,9 +2,8 @@ import { HDNode, ECPair, networks } from 'bitgo-utxo-lib';
 import { ExtendedKeys } from '../coin/baseCoin/iface';
 
 /**
- * Get the uncompressed public key from a BIP32 xpub
- * @param {String} xpub the xpub to extract the compressed public key from
- * @return the compressed public key in hexadecimal
+ * @param {String} xpub - a base-58 encoded extended public key (BIP32)
+ * @return {String} the uncompressed public key in hexadecimal
  */
 export function xpubToUncompressedPub(xpub: string): string {
   if (!isValidXpub(xpub)) {
@@ -15,11 +14,10 @@ export function xpubToUncompressedPub(xpub: string): string {
 }
 
 /**
- * Get the original private key from its extended version.
- * @param xprv In base 58
- * @return the original compressed public key
+ * @param {String} xprv - base58-encoded extended private key (BIP32)
+ * @return {String} the hex-encoded raw private key
  */
-export function xprvToCompressedPrv(xprv: string): string {
+export function xprvToRawPrv(xprv: string): string {
   if (!isValidXprv(xprv)) {
     throw new Error('invalid xprv');
   }
@@ -28,11 +26,10 @@ export function xprvToCompressedPrv(xprv: string): string {
 }
 
 /**
- * Get the extended public and private key for a compressed private key.
- * @param prv Private key in hex format to get the extended keys for
- * @return xprv and xpub in string format
+ * @param {String} prv - Private key in hex format to get the extended keys for
+ * @return {ExtendedKeys} xprv and xpub in string format
  */
-export function compressedPrvToExtendedKeys(prv: string): ExtendedKeys {
+export function rawPrvToExtendedKeys(prv: string): ExtendedKeys {
   const keyPair = ECPair.fromPrivateKeyBuffer(Buffer.from(prv, 'hex'));
   const hd = new HDNode(keyPair, Buffer.alloc(32));
   return {

--- a/test/unit/coin/trx/keyPair.ts
+++ b/test/unit/coin/trx/keyPair.ts
@@ -64,7 +64,7 @@ describe('Trx KeyPair', function() {
       should.throws(() => keyPair.getExtendedKeys());
     });
 
-    it('from a compressed private key', () => {
+    it('from a raw private key', () => {
       const source = {
         prv: '82A34E3867EA7EA4E67E27865D500AE84E98D07AB1BAB06526F0A5A5FDCC3EBA'
       };

--- a/test/unit/coin/trx/trx.ts
+++ b/test/unit/coin/trx/trx.ts
@@ -58,7 +58,7 @@ describe('Tron', function() {
 
       it('a signed transaction with an xprv', () => {
         txBuilder.from(FirstSigOnBuildTransaction);
-        const SecondPrivateKeyXprv = Crypto.compressedPrvToExtendedKeys(SecondPrivateKey);
+        const SecondPrivateKeyXprv = Crypto.rawPrvToExtendedKeys(SecondPrivateKey);
         txBuilder.sign({ key: SecondPrivateKeyXprv.xprv});
         const tx = txBuilder.build();
 

--- a/test/unit/utils/crypto.ts
+++ b/test/unit/utils/crypto.ts
@@ -11,15 +11,15 @@ describe('Crypto utils', function() {
       pub.should.equal('040706358b2bf2917d7be11a692681d9e7266e431b2dc124cb15ba6d98501ecab091e6e25ce84278c56e1e264b69df67b3f37e2a7ffe41f3f56a07fb393095d5b1');
     });
 
-    it('to get a valid compressed private key from an xprv', () => {
-      const prv = Crypto.xprvToCompressedPrv('xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzF9HJ1Z6954LhpFkdHzUXfqoE7GH6eyJvQSfYuAdK2gXGjM6mvd2');
+    it('to get a valid raw private key from an xprv', () => {
+      const prv = Crypto.xprvToRawPrv('xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzF9HJ1Z6954LhpFkdHzUXfqoE7GH6eyJvQSfYuAdK2gXGjM6mvd2');
 
       should.exist(prv);
       prv.should.equal('1f3cd7a858a11eef3e3f591cb5532241ce12c26b588197c88ebb42c6b6cbb5ba');
     });
 
-    it('to get a valid extended keys from a compressed private key', () => {
-      const pub = Crypto.compressedPrvToExtendedKeys('1F3CD7A858A11EEF3E3F591CB5532241CE12C26B588197C88EBB42C6B6CBB5BA');
+    it('to get a valid extended keys from a raw private key', () => {
+      const pub = Crypto.rawPrvToExtendedKeys('1F3CD7A858A11EEF3E3F591CB5532241CE12C26B588197C88EBB42C6B6CBB5BA');
 
       should.exist(pub.xprv);
       should.exist(pub.xpub);
@@ -33,12 +33,12 @@ describe('Crypto utils', function() {
       should.throws(() => Crypto.xpubToUncompressedPub('xpub'));
     });
 
-    it('to get a valid compressed private key from an invalid xprv', () => {
-      should.throws(() => Crypto.xprvToCompressedPrv('xprv'));
+    it('to get a valid raw private key from an invalid xprv', () => {
+      should.throws(() => Crypto.xprvToRawPrv('xprv'));
     });
 
-    it('to get a valid extended keys from an invalid compressed private key', () => {
-      should.throws(() => Crypto.compressedPrvToExtendedKeys('ABCD'));
+    it('to get a valid extended keys from an invalid raw private key', () => {
+      should.throws(() => Crypto.rawPrvToExtendedKeys('ABCD'));
     });
   });
 });


### PR DESCRIPTION
There are no "compressed" private keys. A more apt terminology for a
hex-encoded private key (the `d` value) would be the `raw`
private key.

This is in preparation of removing the dependency on `bitgo-utxo-lib`.