### PR TITLE
Add sign and verify message functions

### DIFF
--- a/src/coin/trx/keyPair.ts
+++ b/src/coin/trx/keyPair.ts
@@ -123,4 +123,32 @@ export class KeyPair {
     }
     throw new Error('Unsupported address format');
   }
+
+  /**
+   * Generates a signature for an arbitrary string with the current private key using keccak256
+   * hashing algorithm. Throws if there is no private key.
+   * @param {string} message to produce a signature for
+   * @return The signature as a buffer
+   */
+  signMessage(message: string): Buffer {
+    const messageToSign = Buffer.from(message).toString('hex');
+    const { prv } = this.getKeys();
+    if (!prv) {
+      throw new Error('Missing private key');
+    }
+    const signature = Utils.signString(messageToSign, prv, true).replace(/^0x/, '');
+    return Buffer.from(signature, 'hex');
+  }
+
+  /**
+   * Verifies a message signature using the current public key.
+   * @param {string} message signed
+   * @param {Buffer} signature to verify
+   * @return True if the message was signed with the current key pair
+   */
+  verifySignature(message: string, signature: Buffer): boolean {
+    const messageToVerify = Buffer.from(message).toString('hex');
+    const address = this.getAddress(AddressFormat.base58);
+    return Utils.verifySignature(messageToVerify, address, signature.toString('hex'), true);
+  }
 }

--- a/src/coin/trx/utils.ts
+++ b/src/coin/trx/utils.ts
@@ -36,7 +36,7 @@ export function verifySignature(
   base58Address: string,
   sigHex: string,
   useTronHeader = true,
-): ByteArray {
+): boolean {
   if (!isValidHex(sigHex)) {
     throw new UtilsError('signature is not in a valid format, needs to be hexadecimal');
   }

--- a/test/unit/coin/trx/util.ts
+++ b/test/unit/coin/trx/util.ts
@@ -81,7 +81,7 @@ describe('Util library should', function() {
 
   it('should verify a signed message', () => {
     const hexEncodedMessage = Buffer.from(txt).toString('hex');
-    should.ok(Utils.verifySignature(hexEncodedMessage, base58, signedString, true));
+    Utils.verifySignature(hexEncodedMessage, base58, signedString, true).should.be.true();
   });
 
   it('should fail to verify a signed message if the message is not in hex', () => {


### PR DESCRIPTION
[XTZ-29](https://bitgoinc.atlassian.net/browse/XTZ-29) Add methods to sign and verify random string messages using the current Key Pair.

This is used to prove that a sender has control over the private keys.