### PR TITLE
Validate transaction implementation

### DIFF
--- a/src/coin/baseCoin/errors.ts
+++ b/src/coin/baseCoin/errors.ts
@@ -43,3 +43,9 @@ export class ExtendTransactionError extends ExtendableError {
     super(message);
   }
 }
+
+export class InvalidIDError extends ExtendableError {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/coin/baseCoin/errors.ts
+++ b/src/coin/baseCoin/errors.ts
@@ -44,7 +44,7 @@ export class ExtendTransactionError extends ExtendableError {
   }
 }
 
-export class InvalidIDError extends ExtendableError {
+export class InvalidTransactionError extends ExtendableError {
   constructor(message: string) {
     super(message);
   }

--- a/src/coin/trx/transactionBuilder.ts
+++ b/src/coin/trx/transactionBuilder.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 import BigNumber from 'bignumber.js';
 
 import { TransactionReceipt } from './iface';
@@ -121,8 +122,18 @@ export class TransactionBuilder extends BaseTransactionBuilder {
     // TODO: parse the transaction raw_data_hex and compare it with the raw_data
   }
 
+  /**
+   * Validates a transaction has the right transaction id.
+   */
   validateTransaction(transaction: Transaction) {
-    // TODO: verify the transaction has the right transaction id
+    const hexBuffer = Buffer.from(transaction.toJson().raw_data_hex, 'hex');
+    const txId = crypto
+      .createHash('sha256')
+      .update(hexBuffer)
+      .digest('hex');
+    if (transaction.id != txId) {
+      throw new Error(transaction.id + ' is not a valid transaction id');
+    }
   }
 
   displayName(): string {

--- a/src/coin/trx/transactionBuilder.ts
+++ b/src/coin/trx/transactionBuilder.ts
@@ -2,7 +2,7 @@ import * as crypto from 'crypto';
 import BigNumber from 'bignumber.js';
 
 import { TransactionReceipt } from './iface';
-import { SigningError, BuildTransactionError } from '../baseCoin/errors';
+import { SigningError, BuildTransactionError, InvalidIDError } from '../baseCoin/errors';
 import { Address } from './address';
 import { BaseKey } from '../baseCoin/iface';
 import { signTransaction, isBase58Address } from './utils';
@@ -122,9 +122,7 @@ export class TransactionBuilder extends BaseTransactionBuilder {
     // TODO: parse the transaction raw_data_hex and compare it with the raw_data
   }
 
-  /**
-   * Validates a transaction has the right transaction id.
-   */
+  /** @inheritDoc Specifically, checks hex underlying transaction hashes to correct transaction ID. */
   validateTransaction(transaction: Transaction) {
     const hexBuffer = Buffer.from(transaction.toJson().raw_data_hex, 'hex');
     const txId = crypto
@@ -132,7 +130,7 @@ export class TransactionBuilder extends BaseTransactionBuilder {
       .update(hexBuffer)
       .digest('hex');
     if (transaction.id != txId) {
-      throw new Error(transaction.id + ' is not a valid transaction id');
+      throw new InvalidIDError(transaction.id + ' is not a valid transaction id. Expecting: ' + txId);
     }
   }
 

--- a/src/coin/trx/transactionBuilder.ts
+++ b/src/coin/trx/transactionBuilder.ts
@@ -2,7 +2,7 @@ import * as crypto from 'crypto';
 import BigNumber from 'bignumber.js';
 
 import { TransactionReceipt } from './iface';
-import { SigningError, BuildTransactionError, InvalidIDError } from '../baseCoin/errors';
+import { SigningError, BuildTransactionError, InvalidTransactionError } from '../baseCoin/errors';
 import { Address } from './address';
 import { BaseKey } from '../baseCoin/iface';
 import { signTransaction, isBase58Address } from './utils';
@@ -130,7 +130,7 @@ export class TransactionBuilder extends BaseTransactionBuilder {
       .update(hexBuffer)
       .digest('hex');
     if (transaction.id != txId) {
-      throw new InvalidIDError(transaction.id + ' is not a valid transaction id. Expecting: ' + txId);
+      throw new InvalidTransactionError(transaction.id + ' is not a valid transaction id. Expecting: ' + txId);
     }
   }
 

--- a/test/resources/trx.ts
+++ b/test/resources/trx.ts
@@ -204,3 +204,28 @@ export const SignedAccountPermissionUpdateContractTx = {
     '2bc5030727d42ed642c2806a3c1a5a0393408b159541f2163df4ba692c5c1240e2dde5a2aae4ecad465414e60b5aeca8522d0a2b6606f88a326658809161334f00'
   ]
 };
+
+export const InvalidIDTransaction = {
+  visible: false,
+  txID:
+      '90b8b9eaed51c8bba3b49f7f0e7cc5f21ac99a6f3e2893c663b544bf2c695b1d',
+  raw_data:
+      { contract:
+            [ { parameter:
+                  {
+                    value:
+                        {
+                          amount: 1718,
+                          owner_address: '41c4530f6bfa902b7398ac773da56106a15af15f92',
+                          to_address: '4189ffaf9da8c6fae32189b2e6dce228249b1129aa'
+                        },
+                    type_url: 'type.googleapis.com/protocol.TransferContract'
+                  },
+              type: 'TransferContract' } ],
+        ref_block_bytes: '90e4',
+        ref_block_hash: 'a018bf9892ddb138',
+        expiration: 1571811468000,
+        timestamp: 1571811410819 },
+  raw_data_hex:
+      '0a0290e42208a018bf9892ddb13840e0c58ebadf2d5a66080112620a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412310a1541c4530f6bfa902b7398ac773da56106a15af15f9212154189ffaf9da8c6fae32189b2e6dce228249b1129aa18b60d7083878bbadf2d',
+};

--- a/test/unit/coin/trx/transactionBuilder.ts
+++ b/test/unit/coin/trx/transactionBuilder.ts
@@ -172,12 +172,5 @@ describe('Tron', function() {
       // Build calls validateTransaction()
       should.throws(() => txBuilder.build());
     });
-
-    it('should build a valid transaction', () => {
-      const txJson = JSON.stringify(UnsignedBuildTransaction);
-      txBuilder.from(txJson);
-      txBuilder.sign({ key: FirstPrivateKey });
-      txBuilder.build();
-    });
   });
 });

--- a/test/unit/coin/trx/transactionBuilder.ts
+++ b/test/unit/coin/trx/transactionBuilder.ts
@@ -8,6 +8,7 @@ import {
   SecondPrivateKey,
   UnsignedAccountPermissionUpdateContractTx,
   AccountPermissionUpdateContractPriv,
+  InvalidIDTransaction,
 } from '../../../resources/trx';
 import { getBuilder } from "../../../../src";
 import * as Crypto from "../../../../src/utils/crypto";
@@ -162,6 +163,21 @@ describe('Tron', function() {
       tx.outputs[0].address.should.equal('TNYssiPgaf9XYz3urBUqr861Tfqxvko47B');
       tx.outputs[0].value.toString().should.equal('1718');
       tx.validFrom.should.equal(1571811410819);
+    });
+
+    it('should catch an invalid id', () => {
+      const txJson = JSON.stringify(InvalidIDTransaction);
+      txBuilder.from(txJson);
+      txBuilder.sign({ key: FirstPrivateKey });
+      // Build calls validateTransaction()
+      should.throws(() => txBuilder.build());
+    });
+
+    it('should build a valid transaction', () => {
+      const txJson = JSON.stringify(UnsignedBuildTransaction);
+      txBuilder.from(txJson);
+      txBuilder.sign({ key: FirstPrivateKey });
+      txBuilder.build();
     });
   });
 });


### PR DESCRIPTION
Fixes #37 

As specified, `validateTransaction()` verifies a Tron transaction has the right transaction id, per the [Tron spec](https://github.com/tronprotocol/documentation/blob/master/TRX/Tron-overview.md). Introduced the crypto library from standard lib.

Unit tests included.

