### PR TITLE
Implement hash validation for Tezos

### DIFF
--- a/src/coin/xtz/iface.ts
+++ b/src/coin/xtz/iface.ts
@@ -3,21 +3,21 @@
  */
 export type PrivateKey = {
   prv: string;
-}
+};
 
 /**
  * A Tezos public key with the sppk prefix or raw
  */
 export type PublicKey = {
   pub: string;
-}
+};
 
 /**
  * A seed to create Tezos key pairs. Must be between 16 and 64 Bytes long
  */
 export type Seed = {
   seed: Buffer;
-}
+};
 
 export type KeyPairOptions = Seed | PrivateKey | PublicKey;
 
@@ -31,4 +31,9 @@ export function isPrivateKey(source: KeyPairOptions): source is PrivateKey {
 
 export function isPublicKey(source: KeyPairOptions): source is PublicKey {
   return (source as PublicKey).pub !== undefined;
+}
+
+export interface HashType {
+  prefix: Buffer;
+  byteLength: number;
 }

--- a/src/coin/xtz/keyPair.ts
+++ b/src/coin/xtz/keyPair.ts
@@ -53,8 +53,8 @@ export class KeyPair {
     } else if (CryptoUtils.isValidPrv(prv)) {
       // Cannot create the HD node without the chain code, so create a regular Key Chain
       this.keyPair = ECPair.fromPrivateKeyBuffer(new Buffer(prv, 'hex'));
-    } else if (Utils.isValidTezosKey(Utils.prefix.spsk, prv)) {
-      this.keyPair = ECPair.fromPrivateKeyBuffer(Utils.decodeKey(Utils.prefix.spsk, prv));
+    } else if (Utils.isValidKey(prv, Utils.hashTypes.spsk)) {
+      this.keyPair = ECPair.fromPrivateKeyBuffer(Utils.decodeKey(prv, Utils.hashTypes.spsk));
     } else {
       throw new Error('Unsupported private key');
     }
@@ -71,8 +71,8 @@ export class KeyPair {
     } else if (CryptoUtils.isValidPub(pub)) {
       // Cannot create an HD node without the chain code, so create a regular Key Chain
       this.keyPair = ECPair.fromPublicKeyBuffer(new Buffer(pub, 'hex'));
-    } else if (Utils.isValidTezosKey(Utils.prefix.sppk, pub)) {
-      this.keyPair = ECPair.fromPublicKeyBuffer(Utils.decodeKey(Utils.prefix.sppk, pub));
+    } else if (Utils.isValidKey(pub, Utils.hashTypes.sppk)) {
+      this.keyPair = ECPair.fromPublicKeyBuffer(Utils.decodeKey(pub, Utils.hashTypes.sppk));
     } else {
       throw new Error('Unsupported public key: ' + pub);
     }
@@ -87,12 +87,12 @@ export class KeyPair {
     const pub = this.keyPair.Q.getEncoded(true);
 
     const result: DefaultKeys = {
-      pub: Utils.base58encode(Utils.prefix.sppk, pub),
+      pub: Utils.base58encode(Utils.hashTypes.sppk.prefix, pub),
     };
 
     if (this.keyPair.d) {
       const prv = this.keyPair.getPrivateKeyBuffer();
-      result.prv = Utils.base58encode(Utils.prefix.spsk, prv);
+      result.prv = Utils.base58encode(Utils.hashTypes.spsk.prefix, prv);
     }
     return result;
   }
@@ -125,6 +125,6 @@ export class KeyPair {
       .update(pub)
       .digest(out);
 
-    return Utils.base58encode(Utils.prefix.tz2, b2b);
+    return Utils.base58encode(Utils.hashTypes.tz2.prefix, b2b);
   }
 }

--- a/test/unit/coin/xtz/keyPair.ts
+++ b/test/unit/coin/xtz/keyPair.ts
@@ -8,7 +8,8 @@ describe('Xtz KeyPair', function() {
   describe('should create a KeyPair', function() {
     it('from an xpub', () => {
       const source = {
-        pub: 'xpub661MyMwAqRbcFhCvdhTAfpEEDV58oqDvv65YNHC686NNs4KbH8YZQJWVmrfbve7aAVHzxw8bKFxA7MLeDK6BbLfkE3bqkvHLPgaGHHtYGeY'
+        pub:
+          'xpub661MyMwAqRbcFhCvdhTAfpEEDV58oqDvv65YNHC686NNs4KbH8YZQJWVmrfbve7aAVHzxw8bKFxA7MLeDK6BbLfkE3bqkvHLPgaGHHtYGeY',
       };
       const keyPair = new Xtz.KeyPair(source);
       const defaultKeys = keyPair.getKeys();
@@ -17,12 +18,15 @@ describe('Xtz KeyPair', function() {
 
       const extendedKeys = keyPair.getExtendedKeys();
       should.not.exist(extendedKeys.xprv);
-      extendedKeys.xpub.should.equal('xpub661MyMwAqRbcFhCvdhTAfpEEDV58oqDvv65YNHC686NNs4KbH8YZQJWVmrfbve7aAVHzxw8bKFxA7MLeDK6BbLfkE3bqkvHLPgaGHHtYGeY');
+      extendedKeys.xpub.should.equal(
+        'xpub661MyMwAqRbcFhCvdhTAfpEEDV58oqDvv65YNHC686NNs4KbH8YZQJWVmrfbve7aAVHzxw8bKFxA7MLeDK6BbLfkE3bqkvHLPgaGHHtYGeY',
+      );
     });
 
     it('from an xprv', () => {
       const source = {
-        prv: 'xprv9s21ZrQH143K3D8TXfvAJgHVfTEeQNW5Ys9wZtnUZkqPzFzSjbEJrWC1vZ4GnXCvR7rQL2UFX3RSuYeU9MrERm1XBvACow7c36vnz5iYyj2'
+        prv:
+          'xprv9s21ZrQH143K3D8TXfvAJgHVfTEeQNW5Ys9wZtnUZkqPzFzSjbEJrWC1vZ4GnXCvR7rQL2UFX3RSuYeU9MrERm1XBvACow7c36vnz5iYyj2',
       };
       const keyPair = new Xtz.KeyPair(source);
       const defaultKeys = keyPair.getKeys();
@@ -30,13 +34,18 @@ describe('Xtz KeyPair', function() {
       defaultKeys.pub.should.equal('sppk7csjXKT4wvUNCPMfAgZMNuvSjzW4Y2ZAKZEdvyEPtYagE6pCwkw');
 
       const extendedKeys = keyPair.getExtendedKeys();
-      extendedKeys.xprv!.should.equal('xprv9s21ZrQH143K3D8TXfvAJgHVfTEeQNW5Ys9wZtnUZkqPzFzSjbEJrWC1vZ4GnXCvR7rQL2UFX3RSuYeU9MrERm1XBvACow7c36vnz5iYyj2');
-      extendedKeys.xpub.should.equal('xpub661MyMwAqRbcFhCvdhTAfpEEDV58oqDvv65YNHC686NNs4KbH8YZQJWVmrfbve7aAVHzxw8bKFxA7MLeDK6BbLfkE3bqkvHLPgaGHHtYGeY');
+      extendedKeys.xprv!.should.equal(
+        'xprv9s21ZrQH143K3D8TXfvAJgHVfTEeQNW5Ys9wZtnUZkqPzFzSjbEJrWC1vZ4GnXCvR7rQL2UFX3RSuYeU9MrERm1XBvACow7c36vnz5iYyj2',
+      );
+      extendedKeys.xpub.should.equal(
+        'xpub661MyMwAqRbcFhCvdhTAfpEEDV58oqDvv65YNHC686NNs4KbH8YZQJWVmrfbve7aAVHzxw8bKFxA7MLeDK6BbLfkE3bqkvHLPgaGHHtYGeY',
+      );
     });
 
     it('from an uncompressed public key', () => {
       const source = {
-        pub: '04D63D9FD9FD772A989C5B90EDB37716406356E98273E5F98FE07652247A3A827503E948A2FDBF74A981D4E0054F10EDA7042C2D469F44473D3C7791E0E326E355'
+        pub:
+          '04D63D9FD9FD772A989C5B90EDB37716406356E98273E5F98FE07652247A3A827503E948A2FDBF74A981D4E0054F10EDA7042C2D469F44473D3C7791E0E326E355',
       };
       const keyPair = new Xtz.KeyPair(source);
       const defaultKeys = keyPair.getKeys();
@@ -48,7 +57,7 @@ describe('Xtz KeyPair', function() {
 
     it('from a compressed public key', () => {
       const source = {
-        pub: '03D63D9FD9FD772A989C5B90EDB37716406356E98273E5F98FE07652247A3A8275'
+        pub: '03D63D9FD9FD772A989C5B90EDB37716406356E98273E5F98FE07652247A3A8275',
       };
       const keyPair = new Xtz.KeyPair(source);
       const defaultKeys = keyPair.getKeys();
@@ -60,7 +69,7 @@ describe('Xtz KeyPair', function() {
 
     it('from a Tezos public key', () => {
       const source = {
-        pub: 'sppk7csjXKT4wvUNCPMfAgZMNuvSjzW4Y2ZAKZEdvyEPtYagE6pCwkw'
+        pub: 'sppk7csjXKT4wvUNCPMfAgZMNuvSjzW4Y2ZAKZEdvyEPtYagE6pCwkw',
       };
       const keyPair = new Xtz.KeyPair(source);
       const defaultKeys = keyPair.getKeys();
@@ -72,7 +81,7 @@ describe('Xtz KeyPair', function() {
 
     it('from a raw private key', () => {
       const source = {
-        prv: '82A34E3867EA7EA4E67E27865D500AE84E98D07AB1BAB06526F0A5A5FDCC3EBA'
+        prv: '82A34E3867EA7EA4E67E27865D500AE84E98D07AB1BAB06526F0A5A5FDCC3EBA',
       };
       const keyPair = new Xtz.KeyPair(source);
       const defaultKeys = keyPair.getKeys();
@@ -84,7 +93,7 @@ describe('Xtz KeyPair', function() {
 
     it('from a Tezos private key', () => {
       const source = {
-        prv: 'spsk2R6ek35CtfJMt2XHPWgFcf1wUGLK2fKbU3f4hWZNABo1YrrqP7'
+        prv: 'spsk2R6ek35CtfJMt2XHPWgFcf1wUGLK2fKbU3f4hWZNABo1YrrqP7',
       };
       const keyPair = new Xtz.KeyPair(source);
       const defaultKeys = keyPair.getKeys();
@@ -103,14 +112,14 @@ describe('Xtz KeyPair', function() {
 
     it('from an invalid public key', () => {
       const source = {
-        pub: '01D63D'
+        pub: '01D63D',
       };
       should.throws(() => new Xtz.KeyPair(source));
     });
 
     it('from an invalid private key', () => {
       const source = {
-        prv: '82A34E'
+        prv: '82A34E',
       };
       should.throws(() => new Xtz.KeyPair(source));
     });
@@ -144,8 +153,12 @@ describe('Xtz KeyPair', function() {
     it('should get the keys in extended format', () => {
       const keyPair = new Xtz.KeyPair(defaultSeed);
       const { xprv, xpub } = keyPair.getExtendedKeys();
-      xprv!.should.equal('xprv9s21ZrQH143K3D8TXfvAJgHVfTEeQNW5Ys9wZtnUZkqPzFzSjbEJrWC1vZ4GnXCvR7rQL2UFX3RSuYeU9MrERm1XBvACow7c36vnz5iYyj2');
-      xpub.should.equal('xpub661MyMwAqRbcFhCvdhTAfpEEDV58oqDvv65YNHC686NNs4KbH8YZQJWVmrfbve7aAVHzxw8bKFxA7MLeDK6BbLfkE3bqkvHLPgaGHHtYGeY');
+      xprv!.should.equal(
+        'xprv9s21ZrQH143K3D8TXfvAJgHVfTEeQNW5Ys9wZtnUZkqPzFzSjbEJrWC1vZ4GnXCvR7rQL2UFX3RSuYeU9MrERm1XBvACow7c36vnz5iYyj2',
+      );
+      xpub.should.equal(
+        'xpub661MyMwAqRbcFhCvdhTAfpEEDV58oqDvv65YNHC686NNs4KbH8YZQJWVmrfbve7aAVHzxw8bKFxA7MLeDK6BbLfkE3bqkvHLPgaGHHtYGeY',
+      );
     });
 
     it('should get the keys in extended format  for a random seed', () => {

--- a/test/unit/coin/xtz/util.ts
+++ b/test/unit/coin/xtz/util.ts
@@ -1,0 +1,85 @@
+import * as should from 'should';
+import * as Utils from '../../../../src/coin/xtz/utils';
+
+describe('XTZ util library', function() {
+  describe('address', function() {
+    it('should validate addresses', function() {
+      const validAddresses = [
+        'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+        'tz2SHdGxFGhs68wYNC4hEqxbWARxp2J4mVxv',
+        'tz3gN8NTLNLJg5KRsUU47NHNVHbdhcFXjjaB',
+        'KT1EGbAxguaWQFkV3Egb2Z1r933MWuEYyrJS',
+      ];
+
+      for (const address of validAddresses) {
+        Utils.isValidAddress(address).should.be.true();
+      }
+    });
+
+    it('should fail to validate invalid addresses', function() {
+      const invalidAddresses = [
+        'tz4aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+        'xtz2SHdGxFGhs68wYNC4hEqxbWARxp2J4mVxv',
+        'KT2EGbAxguaWQFkV3Egb2Z1r933MWuEYyrJS',
+        'abc',
+      ];
+
+      for (const address of invalidAddresses) {
+        should.doesNotThrow(() => Utils.isValidAddress(address));
+        Utils.isValidAddress(address).should.be.false();
+      }
+    });
+  });
+
+  describe('block hash', function() {
+    it('should validate block hashes', function() {
+      const validHashes = [
+        'BKoifs5gGffAzuRBcg3ygxbLdrCXyDDS1ALvMG8SFYWahzoYMku',
+        'BL4oxWAkozJ3mJHwVFQqga5dQMBi8kBCPAQyBKgF78z7SQT1AvN',
+        'BL29n92KHaarq1r7XjwTFotzCpxq7LtXMc9bF2qD9Qt26ZTYQia',
+      ];
+
+      for (const hash of validHashes) {
+        Utils.isValidBlockHash(hash).should.be.true();
+      }
+    });
+
+    it('should fail to validate invalid block hashes', function() {
+      const invalidHashes = [
+        'AKoifs5gGffAzuRBcg3ygxbLdrCXyDDS1ALvMG8SFYWahzoYMku',
+        'BKoifs5gGffAzuRBcg3ygxbLdrCXyDDS1ALvMG8SFYWahzoYMku1111111111',
+        'invalid',
+      ];
+
+      for (const hash of invalidHashes) {
+        Utils.isValidBlockHash(hash).should.be.false();
+      }
+    });
+  });
+
+  describe('transaction hash', function() {
+    it('should validate tx hashes', function() {
+      const validHashes = [
+        'opUmZNMueryYFxTbzzocS7K4dzs3NmgKqhhr9TkcftszDDnoRVu',
+        'ookyzxsYF7vyTeDzsgs58XJ4PXuvBkK8wWqZJ4EoRS6RWQb4Y9P',
+        'ooXQoUX32szALRvgzD2TDzeRPXtPfmfqwoehPaK5khbrBiMAtSw',
+      ];
+
+      for (const hash of validHashes) {
+        Utils.isValidTransactionHash(hash).should.be.true();
+      }
+    });
+
+    it('should fail to validate invalid tx hashes', function() {
+      const invalidHashes = [
+        'lpUmZNMueryYFxTbzzocS7K4dzs3NmgKqhhr9TkcftszDDnoRVu',
+        'opUmZNMueryYFxTbzzocS7K4dzs3NmgKqhhr9TkcftszDDnoRVu1111111111',
+        'invalid',
+      ];
+
+      for (const hash of invalidHashes) {
+        Utils.isValidTransactionHash(hash).should.be.false();
+      }
+    });
+  });
+});


### PR DESCRIPTION
Add validation for address, block and transaction hashes
Validate encoding, prefix and length

In Tezos, hashes are encoded using Base58Check

Ticket: BG-17820