### PR TITLE
Bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/account-lib",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "BitGo's account library functions",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/src/coin/trx/transactionBuilder.ts
+++ b/src/coin/trx/transactionBuilder.ts
@@ -78,7 +78,7 @@ export class TransactionBuilder extends BaseTransactionBuilder {
   }
 
   /** @inheritdoc */
-  protected buildImplementation(): Promise<Transaction> {
+  protected async buildImplementation(): Promise<Transaction> {
     // This is a no-op since Tron transactions are built from
     if (!this.transaction.id) {
       throw new BuildTransactionError('A valid transaction must have an id');

--- a/test/resources/testTransactionBuilder.ts
+++ b/test/resources/testTransactionBuilder.ts
@@ -41,7 +41,7 @@ export class TestTransactionBuilder extends BaseTransactionBuilder {
     return this._transaction;
   }
 
-  public buildImplementation(): Promise<BaseTransaction> {
+  public async buildImplementation(): Promise<BaseTransaction> {
     return Promise.resolve(this._transaction);
   }
 


### PR DESCRIPTION
Update MAJOR version, since the transactionBuilder’s build() method is now async.

See: https://github.com/BitGo/bitgo-account-lib/pull/54/files#diff-4e77c7638c5579df1efa8d2624cd3480R65

Ticket: BG-18616