### PR TITLE
Make sign order optional

### DIFF
--- a/src/coin/xtz/iface.ts
+++ b/src/coin/xtz/iface.ts
@@ -117,7 +117,6 @@ export interface IndexedData {
  */
 export interface Key extends BaseKey, IndexedData {}
 
-export interface IndexedSignature {
+export interface IndexedSignature extends IndexedData {
   signature: string;
-  index: number;
 }

--- a/src/coin/xtz/multisigUtils.ts
+++ b/src/coin/xtz/multisigUtils.ts
@@ -119,7 +119,7 @@ export function multisigTransactionOperation(
   contractAddress: string,
   contractCounter: string,
   destinationAddress: string,
-  signatures: { signature: string; index: number }[],
+  signatures: IndexedSignature[],
   fee: string = DEFAULT_FEE.TRANSFER.toString(),
   gasLimit: string = DEFAULT_GAS_LIMIT.TRANSFER.toString(),
   storageLimit: string = DEFAULT_STORAGE_LIMIT.TRANSFER.toString(),
@@ -200,7 +200,19 @@ function buildSignatures(signatures: IndexedSignature[], existingSignatures = []
     transactionSignatures.push({ prim: 'None' });
   }
   // Replace the empty signatures for the real ones based on the right index
-  signatures.forEach(s => (transactionSignatures[s.index] = { prim: 'Some', args: [{ string: s.signature }] }));
+  signatures.forEach(s => {
+    if (s.index) {
+      transactionSignatures[s.index] = { prim: 'Some', args: [{ string: s.signature }] };
+    } else {
+      for (let i = 0; i < transactionSignatures.length; i++) {
+        // Search for the first "null" signature
+        if (transactionSignatures[i].prim === 'None') {
+          transactionSignatures[i] = { prim: 'Some', args: [{ string: s.signature }] };
+          break;
+        }
+      }
+    }
+  });
   return transactionSignatures;
 }
 

--- a/src/coin/xtz/transactionBuilder.ts
+++ b/src/coin/xtz/transactionBuilder.ts
@@ -372,12 +372,12 @@ export class TransactionBuilder extends BaseTransactionBuilder {
    * @returns {Promise<string[]>} List of signatures for packedData
    */
   private async getSignatures(packedData: string): Promise<IndexedSignature[]> {
-    const signatures: { signature: string; index: number }[] = [];
+    const signatures: IndexedSignature[] = [];
     // Generate the multisig contract signatures
     for (let i = 0; i < this._multisigSignerKeyPairs.length; i++) {
       const signature = await Utils.sign(this._multisigSignerKeyPairs[i].key, packedData, new Uint8Array(0));
-      const index = this._multisigSignerKeyPairs[i].index || i;
-      signatures.push({ signature: signature.sig, index });
+      const index = this._multisigSignerKeyPairs[i].index;
+      signatures.push(index ? { signature: signature.sig, index } : { signature: signature.sig });
     }
     return signatures;
   }


### PR DESCRIPTION
If the signature index is not provided, search for the first nullified signature and replace it.
This makes the order of the sign operations implicit.

TICKET: BG-17090