### PR TITLE
Add signature verification for Tezos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/account-lib",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -428,11 +428,29 @@
         "buffer": "^5.2.1"
       }
     },
+    "@types/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
+    },
+    "@types/elliptic": {
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
+      "integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
+      "dev": true,
+      "requires": {
+        "@types/bn.js": "*"
+      }
     },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/account-lib",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "BitGo's account library functions",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -39,11 +39,13 @@
     "bitgo-utxo-lib": "^1.6.0",
     "blake2b": "git+https://github.com/BitGo/blake2b.git#6268e6dd678661e0acc4359e9171b97eb1ebf8ac",
     "bs58check": "^2.1.2",
+    "elliptic": "^6.5.2",
     "libsodium-wrappers": "^0.7.6",
     "protobufjs": "^6.8.9",
     "tronweb": "^2.7.2"
   },
   "devDependencies": {
+    "@types/elliptic": "^6.4.12",
     "@types/libsodium-wrappers": "^0.7.7",
     "@types/mocha": "^5.2.6",
     "@types/node": "^11.13.22",


### PR DESCRIPTION
Use [elliptic](https://www.npmjs.com/package/elliptic) to verify the signatures produced by our library.

The decoding operations are based on:
- https://github.com/ecadlabs/taquito/blob/5dc2dee9d6d51430afbccee4c0b6f356de840240/packages/taquito-signer/src/taquito-signer.ts#L74
- https://github.com/ecadlabs/taquito/blob/5dc2dee9d6d51430afbccee4c0b6f356de840240/packages/taquito-signer/src/ec-key.ts#L72