### PR TITLE
Remove coin specific scripts from package.json

### DIFF
--- a/coins.config.json
+++ b/coins.config.json
@@ -1,7 +1,7 @@
 {
   "coins": {
     "TRX":{
-      "packages":"npm run gen-protobuf && npm run gen-protobufts"
+      "packages":"node node_modules/protobufjs/cli/bin/pbjs -t static-module -w commonjs -o ./resources/trx/protobuf/tron.js ./resources/trx/protobuf/Discover.proto ./resources/trx/protobuf/Contract.proto ./resources/trx/protobuf/tron.proto && node node_modules/protobufjs/cli/bin/pbts -o ./resources/trx/protobuf/tron.d.ts ./resources/trx/protobuf/tron.js"
     }
   }
 }

--- a/coins.config.json
+++ b/coins.config.json
@@ -1,0 +1,7 @@
+{
+  "coins": {
+    "TRX":{//Tron coin
+      "packages":"npm run gen-protobuf && npm run gen-protobufts"
+    }
+  }
+}

--- a/coins.config.json
+++ b/coins.config.json
@@ -1,6 +1,6 @@
 {
   "coins": {
-    "TRX":{//Tron coin
+    "TRX":{
       "packages":"npm run gen-protobuf && npm run gen-protobufts"
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "webpack-test": "webpack --progress --colors --env.test",
     "webpack-prod": "webpack --progress --colors --env.prod",
     "build": "tsc && cp -r ./resources ./dist",
-    "build-coin": "cmd=$(cat ./coins.config.json | jq -r .coins.$COIN.packages) | $cmd && tsc && cp -r ./resources ./dist",
+    "postinstall": "cmd=$(cat ./coins.config.json | jq -r .coins.$COIN.packages) | $cmd && tsc && cp -r ./resources ./dist",
     "clean": "rm -rf dist/* && rm -rf node_modules/*",
     "compile": "npm run browserify && npm run webpack-prod",
     "compile-dev": "npm run browserify && npm run webpack-dev",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "coverage": "npm run gen-coverage && npm run upload-coverage",
     "upload-coverage": "codecov -f coverage.lcov -t \"$CODECOV_TOKEN\"",
     "gen-coverage": "./node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov",
-    "gen-protobuf": "node node_modules/protobufjs/cli/bin/pbjs -t static-module -w commonjs -o ./resources/trx/protobuf/tron.js ./resources/trx/protobuf/Discover.proto ./resources/trx/protobuf/Contract.proto ./resources/trx/protobuf/tron.proto",
-    "gen-protobufts": "node node_modules/protobufjs/cli/bin/pbts -o ./resources/trx/protobuf/tron.d.ts ./resources/trx/protobuf/tron.js",
     "lint": "eslint 'src/**/*.ts' && eslint 'test/**/*.ts' && eslint 'resources/xtz/**/*.ts' || true",
     "lint-fix": "eslint 'src/**/*.ts' --fix && eslint 'test/**/*.ts' --fix  && eslint 'resources/xtz/**/*.ts' --fix || true",
     "prepublishOnly": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "webpack-test": "webpack --progress --colors --env.test",
     "webpack-prod": "webpack --progress --colors --env.prod",
     "build": "tsc && cp -r ./resources ./dist",
-    "build-coin": "cat ./coins.config.json | jq -r .coins.$COIN.packages && tsc && cp -r ./resources ./dist",
+    "build-coin": "cmd=$(cat ./coins.config.json | jq -r .coins.$COIN.packages) | $cmd && tsc && cp -r ./resources ./dist",
     "clean": "rm -rf dist/* && rm -rf node_modules/*",
     "compile": "npm run browserify && npm run webpack-prod",
     "compile-dev": "npm run browserify && npm run webpack-dev",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "webpack-dev": "webpack --progress --colors --env.dev",
     "webpack-test": "webpack --progress --colors --env.test",
     "webpack-prod": "webpack --progress --colors --env.prod",
-    "build": "npm run gen-protobuf && npm run gen-protobufts && tsc && cp -r ./resources ./dist",
+    "build": "tsc && cp -r ./resources ./dist",
+    "build-coin": "cat ./coins.config.json | jq -r .coins.$COIN.packages && tsc && cp -r ./resources ./dist",
     "clean": "rm -rf dist/* && rm -rf node_modules/*",
     "compile": "npm run browserify && npm run webpack-prod",
     "compile-dev": "npm run browserify && npm run webpack-dev",
@@ -41,6 +42,7 @@
     "bs58check": "^2.1.2",
     "elliptic": "^6.5.2",
     "libsodium-wrappers": "^0.7.6",
+    "node-jq": "^1.11.0",
     "protobufjs": "^6.8.9",
     "tronweb": "^2.7.2"
   },


### PR DESCRIPTION
I proposal a way to remove coin specific scripts from package.json

1. Creat **coins.config.json** file for coins configurations. Each coin has coins.${_short_name_}.packages as key to retrieve its essential package scripts.
2. New script `build-coin` is added in package.json. [jq](https://github.com/stedolan/jq) is used in the script so it should be installed in system.
3. `COIN=TRX npm run build-coin` is an example command to install the coin specified packages and other essential packages. `TRX` will be passed into script and the packages information in **coins.config.json** will be read into **package.json**.
4. Build process will start when every information is ready.
5. When a new type of coin is ready to be added, just simply add its specific packages information in **coins.config.json** and then call with `COIN=_COINNANE_ npm run build-coin` command.

Hope this clarify my thought and code. Please let me know if there's any question.
