### PR TITLE
Allow xpubs as a valid arguments when revealing public keys

### DIFF
--- a/src/coin/xtz/transactionBuilder.ts
+++ b/src/coin/xtz/transactionBuilder.ts
@@ -277,13 +277,12 @@ export class TransactionBuilder extends BaseTransactionBuilder {
     if (this._publicKeyToReveal) {
       throw new BuildTransactionError('Public key to reveal already set: ' + this._publicKeyToReveal);
     }
-    if (!isValidPublicKey(publicKey)) {
-      throw new BuildTransactionError('Invalid public key: ' + publicKey);
-    }
-    if (new KeyPair({ pub: publicKey }).getAddress() !== this._sourceAddress) {
+
+    const keyPair = new KeyPair({ pub: publicKey });
+    if (keyPair.getAddress() !== this._sourceAddress) {
       throw new BuildTransactionError('Public key does not match the source address: ' + this._sourceAddress);
     }
-    this._publicKeyToReveal = publicKey;
+    this._publicKeyToReveal = keyPair.getKeys().pub;
   }
 
   /**

--- a/test/unit/coin/xtz/transactionBuilder.ts
+++ b/test/unit/coin/xtz/transactionBuilder.ts
@@ -74,7 +74,7 @@ describe('Tezos Transaction builder', function() {
       };
       const keyPair = new Xtz.KeyPair(source);
       txBuilder.source(keyPair.getAddress());
-      txBuilder.publicKey(keyPair.getKeys().pub);
+      txBuilder.publicKey(keyPair.getExtendedKeys().xpub);
       txBuilder.counter('0');
       txBuilder.branch('BM8QdZ92VyaH1s5nwAF9rUXjiPZ3g3Nsn6oYbdKqj2RgHxvWXVS');
       const tx = await txBuilder.build();
@@ -569,7 +569,7 @@ describe('Tezos Transaction builder', function() {
     it('add an invalid public key to reveal', async () => {
       const txBuilder: any = getBuilder('xtz');
       txBuilder.type(TransactionType.AddressInitialization);
-      should.throws(() => txBuilder.publicKey('sppk'), new RegExp('Invalid public key'));
+      should.throws(() => txBuilder.publicKey('sppk'), new RegExp('Unsupported public key'));
     });
 
     it('add the same public key to reveal twice', async () => {


### PR DESCRIPTION
We currently only take Tezos public keys as valid ones when revealing an account, but we should take any other format the `KeyPair` class supports, including xpubs.

TICKET: BG-19342