### PR TITLE
Add test for ETH wallet initialization ser/deser

### DIFF
--- a/test/unit/coin/eth/transactionBuilder.ts
+++ b/test/unit/coin/eth/transactionBuilder.ts
@@ -241,6 +241,26 @@ describe('Eth Transaction builder', function() {
       should.equal(txJson.chainId, 42);
       should.equal(tx.toBroadcastFormat(), testData.TX_BROADCAST);
     });
+
+    it('an init transaction from serialized', async () => {
+      const txBuilder: any = getBuilder('eth');
+      txBuilder.source(defaultKeyPair.getAddress());
+      txBuilder.counter(1);
+      txBuilder.owner('0x6461EC4E9dB87CFE2aeEc7d9b02Aa264edFbf41f');
+      txBuilder.owner('0xf10C8f42BD63D0AeD3338A6B2b661BC6D9fa7C44');
+      txBuilder.owner('0xa4b5666FB4fFEA84Dd848845E1114b84146de4b3');
+      txBuilder.source(defaultKeyPair.getAddress());
+      txBuilder.sign({ key: defaultKeyPair.getKeys().prv });
+      const tx = await txBuilder.build();
+      const serialized = tx.toBroadcastFormat();
+
+      // now rebuild from the signed serialized tx and make sure it stays the same
+      const newTxBuilder: any = getBuilder('eth');
+      newTxBuilder.from(serialized);
+      newTxBuilder.source(defaultKeyPair.getAddress());
+      const newTx = await newTxBuilder.build();
+      should.equal(newTx.toBroadcastFormat(), serialized);
+    });
   });
 
   describe('should fail to sign', () => {


### PR DESCRIPTION
This commit adds a test that ensures that we can serialize and
deserialize transactions back-and-forth and maintain the same output.
This is required by the internal bitgo components as they pass around
serialized transactions and need to be able to parse them again.

Ticket: BG-21074