### PR TITLE
Add Build step to drone yaml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,6 +25,11 @@ steps:
   commands:
   - npm run lint
 
+- name: build
+  image: node:10
+  commands:
+  - npm run build
+
 ---
 kind: pipeline
 name: unit tests (node:10)


### PR DESCRIPTION
Previously it was possible to merge code that passed unit tests but did
not build correctly, as tsc has stricter rules than ts-node. This commit
adds a step to the build pipeline that checks to ensure that the code
actually compiles with `npm run build`.

Ticket: BG-21163