### PR TITLE
Merge CgldTransaction and CeloTransaction

### DIFF
--- a/src/coin/cgld/types.ts
+++ b/src/coin/cgld/types.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js';
+import * as _ from 'lodash';
 import { signTransaction } from '@celo/contractkit/lib/utils/signing-utils';
 import {
   addHexPrefix,
@@ -11,150 +12,132 @@ import {
   ecrecover,
   publicToAddress,
 } from 'ethereumjs-util';
-import { TxData } from '../eth/iface';
-import { EthereumTransaction, EthTransaction } from '../eth/types';
-import { KeyPair, Utils } from '../eth';
+import { EthLikeTransaction, TxData } from '../eth/iface';
+import { EthTransaction } from '../eth/types';
+import { KeyPair } from '../eth';
 
-export class CeloTransaction extends EthereumTransaction {
-  private _from: Buffer;
-  private _senderPubKey?;
-  private _signatures: Buffer[];
-  private _feeCurrency: Buffer = toBuffer('0x');
-  private _gatewayFeeRecipient: Buffer = toBuffer('0x');
-  private _gatewayFee: Buffer = toBuffer('0x');
 
-  constructor(tx: TxData) {
-    super();
-    this.nonce = toBuffer(tx.nonce);
-    this.gasLimit = toBuffer(tx.gasLimit);
-    this.gasPrice = toBuffer(tx.gasPrice);
-    this.data = toBuffer(tx.data);
-    this.value = toBuffer(tx.value !== '0x0' ? tx.value : '0x');
-    if (tx.to) {
-      this.to = toBuffer(tx.to);
-    }
-    if (tx.v) {
-      this.v = toBuffer(tx.v);
-    }
-    if (tx.r) {
-      this.r = toBuffer(tx.r);
-    }
-    if (tx.s) {
-      this.s = toBuffer(tx.s);
-    }
-    if (tx.from) {
-      this._from = toBuffer(tx.from);
-    }
-    this.initRaw();
-  }
+/**
+ * An Ethereum transaction with helpers for serialization and deserialization.
+ */
+export class CgldTransaction implements EthLikeTransaction {
+	private readonly _feeCurrency: Buffer;
+	private readonly _gatewayFeeRecipient: Buffer = toBuffer('0x');
+	private readonly _gatewayFee: Buffer = toBuffer('0x');
 
-  private initRaw() {
-    this.raw = [
-      this.nonce,
-      this.gasPrice,
-      this.gasLimit,
-      this._feeCurrency,
-      this._gatewayFeeRecipient,
-      this._gatewayFee,
-      this.to,
-      this.value,
-      this.data,
-      this.v,
-      this.r,
-      this.s,
-    ];
-  }
+	constructor(private readonly txData: TxData, protected readonly chainId?: string) {
+		this._feeCurrency = toBuffer('0x');
+		this._gatewayFeeRecipient = toBuffer('0x');
+		this._gatewayFee = toBuffer('0x');
+	}
 
-  hash(includeSignature?: boolean): Buffer {
-    let items;
-    if (includeSignature) {
-      items = this.raw;
-    } else {
-      items = this.raw
-        .slice(0, 9)
-        .concat([toBuffer(this.getChainId()), stripZeros(toBuffer(0)), stripZeros(toBuffer(0))]);
-    }
-
-    return rlphash(items);
-  }
-
-  getSenderAddress(): Buffer {
-    if (this._from) {
-      return this._from;
-    }
-    const pubKey = this.getSenderPublicKey();
-    this._from = publicToAddress(pubKey);
-    return this._from;
-  }
-
-  getSenderPublicKey() {
-    if (this.verifySignature()) {
-      // If the signature was verified successfully the _senderPubKey field is defined
-      return this._senderPubKey;
-    }
-    throw new Error('Invalid Signature');
-  }
-
-  serialize(): Buffer {
-    return rlp.encode(this.raw);
-  }
-
-  sign(privateKey: Buffer): void {
-    this._signatures = [this.v, this.r, this.s, privateKey];
-  }
-
-  verifySignature(): boolean {
-    const msgHash = this.hash(false);
-    try {
-      const chainId = this.getChainId();
-      const v = bufferToInt(this.v) - (2 * chainId + 35);
-      this._senderPubKey = ecrecover(msgHash, v + 27, this.r, this.s);
-    } catch (e) {
-      return false;
-    }
-    return !!this._senderPubKey;
-  }
-
-  getChainId(): number {
-    let chainId = bufferToInt(this.v);
-    if (this.r.length && this.s.length) {
-      chainId = (chainId - 35) >> 1;
-    }
-    return chainId;
-  }
-}
-
-export class CgldTransaction extends EthTransaction {
-  constructor(tx: CeloTransaction, chainId?: string) {
-    super(tx, chainId);
-  }
-
-  public static fromJson(tx: TxData): EthTransaction {
+  public static fromJson(tx: TxData): EthLikeTransaction {
     const chainId = addHexPrefix(new BigNumber(Number(tx.chainId)).toString(16));
-    return new CgldTransaction(
-      new CeloTransaction({
-        nonce: addHexPrefix(new BigNumber(tx.nonce).toString(16)),
-        to: tx.to,
-        gasPrice: addHexPrefix(new BigNumber(tx.gasPrice).toString(16)),
-        gasLimit: addHexPrefix(new BigNumber(tx.gasLimit).toString(16)),
-        value: addHexPrefix(new BigNumber(tx.value).toString(16)),
-        data: tx.data === '0x' ? '' : tx.data,
-        from: tx.from,
-        s: tx.s,
-        r: tx.r,
+    return new CgldTransaction(Object.assign({}, tx, {
         v: tx.v || chainId,
       }),
       chainId,
     );
   }
 
+	/**
+	 * Build an ethereum transaction from its string serialization
+	 *
+	 * @param tx The string serialization of the ethereum transaction
+	 */
+	public static fromSerialized(tx: string): EthLikeTransaction {
+		return new CgldTransaction(EthTransaction.fromSerialized(tx).toJson());
+	}
+
+	/** @inheritdoc */
   async sign(keyPair: KeyPair) {
     const privateKey = addHexPrefix(keyPair.getKeys().prv as string);
     const data = this.toJson();
     const rawTransaction = await signTransaction(data, privateKey);
-    rawTransaction.tx.data = data.data;
-    rawTransaction.tx.gasLimit = rawTransaction.tx.gas;
-    this.tx = new CeloTransaction(rawTransaction.tx);
-    this.tx.sign(toBuffer(privateKey));
+    this.txData.v = rawTransaction.tx.v;
+		this.txData.r = rawTransaction.tx.r;
+		this.txData.s = rawTransaction.tx.s;
   }
+
+	/** @inheritdoc */
+	toJson(): TxData {
+		const result: TxData = _.cloneDeep(this.txData);
+
+		if (this.getSenderAddress()) {
+			result.from = this.getSenderAddress();
+		}
+
+		if (this.chainId) {
+			result.chainId = this.chainId;
+		}
+
+		return result;
+	}
+
+	/** @inheritdoc */
+	toSerialized(): string {
+		return addHexPrefix(rlp.encode(this.getRaw()).toString('hex'));
+	}
+
+	private getRaw(): Buffer[] {
+		return [
+			toBuffer(this.txData.nonce),
+			toBuffer(this.txData.gasPrice),
+			toBuffer(this.txData.gasLimit),
+			this._feeCurrency,
+			this._gatewayFeeRecipient,
+			this._gatewayFee,
+			toBuffer(this.txData.to),
+			toBuffer(this.txData.value !== '0x0' ? this.txData.value : '0x'),
+			toBuffer(this.txData.data),
+			toBuffer(this.txData.v),
+			toBuffer(this.txData.r),
+			toBuffer(this.txData.s),
+		];
+	}
+
+	private hash(includeSignature?: boolean): Buffer {
+		let items;
+		if (includeSignature) {
+			items = this.getRaw();
+		} else {
+			items = this.getRaw()
+				.slice(0, 9)
+				.concat([toBuffer(this.getChainId()), stripZeros(toBuffer(0)), stripZeros(toBuffer(0))]);
+		}
+
+		return rlphash(items);
+	}
+
+	private getChainId(): number {
+		if (!(this.txData.v && this.txData.r && this.txData.s)) {
+			throw new Error(`No signature to calculate chain id`);
+		}
+
+
+		let chainId = bufferToInt(Buffer.from(this.txData.v, 'hex'));
+		if (this.txData.r.length && this.txData.s.length) {
+			chainId = (chainId - 35) >> 1;
+		}
+		return chainId;
+	}
+
+	private getSenderAddress(): string | undefined {
+		if (!(this.txData.v && this.txData.r && this.txData.s)) {
+			return undefined;
+		}
+
+		let senderAddress;
+		try {
+			const msgHash = this.hash(false);
+			const chainId = this.getChainId();
+			const v = bufferToInt(Buffer.from(this.txData.v, 'hex')) - (2 * chainId + 35);
+			const senderPubkey = ecrecover(msgHash, v + 27, Buffer.from(this.txData.r, 'hex'), Buffer.from(this.txData.s, 'hex'));
+			senderAddress = addHexPrefix(bufferToHex(publicToAddress(senderPubkey)));
+		} catch (e) {
+			return undefined;
+		}
+
+		return senderAddress;
+	}
 }

--- a/src/coin/eth/iface.ts
+++ b/src/coin/eth/iface.ts
@@ -1,4 +1,5 @@
 import { BaseFee } from '../baseCoin/iface';
+import { KeyPair } from './keyPair';
 
 export interface Fee extends BaseFee {
   gasLimit: string;
@@ -35,4 +36,25 @@ export interface FieldStruct {
   name: string;
   inputs?: any;
   type: string;
+}
+
+/**
+ * An Ethereum transaction with helpers for serialization and deserialization.
+ */
+export interface  EthLikeTransaction {
+	/**
+	 * Sign this transaction with the given key
+	 * @param keyPair The key to sign the transaction with
+	 */
+	sign(keyPair: KeyPair);
+
+	/**
+	 * Return the JSON representation of this transaction
+	 */
+	toJson(): TxData;
+
+	/**
+	 * Return the hex string serialization of this transaction
+	 */
+	toSerialized(): string;
 }

--- a/src/coin/eth/types.ts
+++ b/src/coin/eth/types.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { Transaction as EthereumTx } from 'ethereumjs-tx';
 import { addHexPrefix, bufferToHex, bufferToInt, toBuffer } from 'ethereumjs-util';
-import { TxData } from './iface';
+import { EthLikeTransaction, TxData } from './iface';
 import { KeyPair } from './keyPair';
 
 export abstract class EthereumTransaction {
@@ -25,7 +25,7 @@ export abstract class EthereumTransaction {
 /**
  * An Ethereum transaction with helpers for serialization and deserialization.
  */
-export class EthTransaction {
+export class EthTransaction implements EthLikeTransaction {
   constructor(public tx: EthereumTransaction, protected chainId?: string) {}
 
   /**
@@ -56,14 +56,13 @@ export class EthTransaction {
     return new EthTransaction(new EthereumTx(tx));
   }
 
+	/** @inheritdoc */
   sign(keyPair: KeyPair) {
     const privateKey = Buffer.from(keyPair.getKeys().prv as string, 'hex');
     this.tx.sign(privateKey);
   }
 
-  /**
-   * Return the JSON representation of this transaction
-   */
+	/** @inheritdoc */
   toJson(): TxData {
     const result: TxData = {
       nonce: bufferToInt(this.tx.nonce),
@@ -88,9 +87,7 @@ export class EthTransaction {
     return result;
   }
 
-  /**
-   * Return the hex string serialization of this transaction
-   */
+	/** @inheritdoc */
   toSerialized(): string {
     return addHexPrefix(this.tx.serialize().toString('hex'));
   }


### PR DESCRIPTION
Since Cgld transactions have slightly different restrictions than ETH
transactions, the EThereumjs-tx library doesn't quite work for
ser/deser/signing of these transactions. This commit merges the existing
fix for this -- CeloTransaction, which implemented the same interface as
Ethereumjs-tx, with the existing CgldTransaction. Since it was not
intended to be exposed outside of a few functions (from/to
JSON/serialized), we could simplify and merge the class into a few
private helper functions