### PR TITLE
Fix 0-prefixed addresses

### DIFF
--- a/src/coin/eth/utils.ts
+++ b/src/coin/eth/utils.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'buffer';
 import {
   addHexPrefix,
+  stripHexPrefix,
   bufferToHex,
   bufferToInt,
   fromRpcSig,
@@ -145,7 +146,11 @@ export function decodeWalletCreationData(data: string): string[] {
     throw new BuildTransactionError(`invalid number of addresses in parsed constructor: ${addresses}`);
   }
 
-  return addresses.map(address => addHexPrefix(address.toString('hex')));
+  // sometimes ethereumjs-abi removes 0 padding at the start of addresses,
+  // so we should pad until they are the standard 20 bytes
+  const paddedAddresses = addresses.map(address => stripHexPrefix(address.toString('hex')).padStart(40, '0'));
+
+  return paddedAddresses.map(address => addHexPrefix(address));
 }
 
 /**

--- a/test/unit/coin/eth/transactionBuilder.ts
+++ b/test/unit/coin/eth/transactionBuilder.ts
@@ -106,6 +106,31 @@ describe('Eth Transaction builder', function() {
       should.equal(txJson.chainId, 42);
     });
 
+    it('an unsigned init transaction from serialized with 0-prefixed address', async () => {
+      const txBuilder: any = getBuilder('eth');
+      txBuilder.type(TransactionType.WalletInitialization);
+      txBuilder.source(defaultKeyPair.getAddress());
+      txBuilder.counter(1);
+      txBuilder.fee({
+        fee: '10000000000',
+        gasLimit: '2000000',
+      });
+      txBuilder.chainId(42);
+      txBuilder.owner('0x6461EC4E9dB87CFE2aeEc7d9b02Aa264edFbf41f');
+      txBuilder.owner('0xf10C8f42BD63D0AeD3338A6B2b661BC6D9fa7C44');
+      txBuilder.owner('0x07ee8b845b8bf0e807e096d6b1599b121b82cbe1');
+      txBuilder.source(defaultKeyPair.getAddress());
+      const tx = await txBuilder.build();
+      const serialized = tx.toBroadcastFormat();
+
+      // now rebuild from the signed serialized tx and make sure it stays the same
+      const newTxBuilder: any = getBuilder('eth');
+      newTxBuilder.from(serialized);
+      newTxBuilder.source(defaultKeyPair.getAddress());
+      const newTx = await newTxBuilder.build();
+      should.equal(newTx.toBroadcastFormat(), serialized);
+    });
+
     it('an unsigned init transaction from serialized', async () => {
       const txBuilder: any = getBuilder('eth');
       txBuilder.type(TransactionType.WalletInitialization);


### PR DESCRIPTION
The transaction builder would fail when deserializing transactions that
started with a 0-prefixed address, because ethereumjs-abi is dumb and
loses that prefix padding when deserializing for some reason. This
commit pads addresses with 0s until they reach the desired 20 byte
length

Ticket: BG-21435