### PR TITLE
Improve transaction builder speed

### DIFF
--- a/src/coin/eth/types.ts
+++ b/src/coin/eth/types.ts
@@ -53,7 +53,7 @@ export class EthTransactionData implements EthLikeTransactionData {
       gasPrice: new BigNumber(bufferToHex(this.tx.gasPrice), 16).toString(10),
       gasLimit: new BigNumber(bufferToHex(this.tx.gasLimit), 16).toString(10),
       value: this.tx.value.length === 0 ? '0' : new BigNumber(bufferToHex(this.tx.value), 16).toString(10),
-      data: addHexPrefix(new BigNumber(bufferToHex(this.tx.data).slice(2), 16).toString(16)),
+      data: bufferToHex(this.tx.data),
       id: addHexPrefix(bufferToHex(this.tx.hash())),
     };
 


### PR DESCRIPTION
The ETH transaction builder was very slow for wallet initialization
transactions because we were parsing data (which can be huge) using
BigNumber, which is slower the bigger the number gets. In fact, we could
keep the data parsing logic very simple here as we just need the hex
string.

Ticket: BG-21437