### PR TITLE
Parse inputs, outputs and signatures for transactions

### DIFF
--- a/src/coin/eth/enum.ts
+++ b/src/coin/eth/enum.ts
@@ -1,8 +1,0 @@
-export enum TransferFieldsIndex {
-  DestinationAddressIndex,
-  AmountIndex,
-  DataOrTokenAddressIndex,
-  ExpirationTimeIndex,
-  SequenceIdIndex,
-  SignatureIndex,
-}

--- a/src/coin/eth/iface.ts
+++ b/src/coin/eth/iface.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js';
 import { BaseFee } from '../baseCoin/iface';
 import { KeyPair } from './keyPair';
 
@@ -72,4 +73,22 @@ export interface ContractMethodConfig {
   contractAddress: string;
   methodId: string;
   types: string[];
+}
+
+export interface TransferData {
+  to: string;
+  amount: string;
+  expireTime: number;
+  sequenceId: number;
+  signature: string;
+  tokenContractAddress?: string;
+  data?: string;
+}
+
+export interface TokenTransferData extends TransferData {
+  tokenContractAddress: string;
+}
+
+export interface NativeTransferData extends TransferData {
+  data: string;
 }

--- a/test/unit/coin/cgld/transactionBuilder/send.ts
+++ b/test/unit/coin/cgld/transactionBuilder/send.ts
@@ -20,19 +20,32 @@ describe('Send transaction', function() {
 
   describe('should sign and build', () => {
     it('a send token transaction', async () => {
+      const recipient = '0x19645032c7f1533395d44a629462e751084d3e4c';
+      const contractAddress = '0x8f977e912ef500548a0c3be6ddde9899f1199b81';
+      const amount = '1000000000';
       initTxBuilder();
-      txBuilder.contract('0x8f977e912ef500548a0c3be6ddde9899f1199b81');
+      txBuilder.contract(contractAddress);
       txBuilder
         .transfer()
         .coin('tcusd')
-        .amount('1000000000')
-        .to('0x19645032c7f1533395d44a629462e751084d3e4c')
+        .amount(amount)
+        .to(recipient)
         .expirationTime(1590066728)
         .contractSequenceId(5)
         .key(key);
       txBuilder.sign({ key: testData.PRIVATE_KEY });
       const tx = await txBuilder.build();
       should.equal(tx.toBroadcastFormat(), testData.SEND_TOKEN_TX_BROADCAST);
+      should.equal(tx.signature.length, 2);
+      should.equal(tx.inputs.length, 1);
+      should.equal(tx.inputs[0].address, contractAddress);
+      should.equal(tx.inputs[0].value, amount);
+      should.equal(tx.inputs[0].coin, 'tcusd');
+
+      should.equal(tx.outputs.length, 1);
+      should.equal(tx.outputs[0].address, recipient);
+      should.equal(tx.outputs[0].value, amount);
+      should.equal(tx.outputs[0].coin, 'tcusd');
     });
 
     it('a send token transactions from serialized', async () => {

--- a/test/unit/coin/eth/transactionBuilder/send.ts
+++ b/test/unit/coin/eth/transactionBuilder/send.ts
@@ -25,7 +25,10 @@ describe('Eth transaction builder send', () => {
   describe('should sign and build', () => {
     let txBuilder;
     let key;
+    let contractAddress;
+
     beforeEach(() => {
+      contractAddress = '0x8f977e912ef500548a0c3be6ddde9899f1199b81';
       txBuilder = getBuilder('cgld') as Eth.TransactionBuilder;
       key = testData.KEYPAIR_PRV.getKeys().prv as string;
       txBuilder.fee({
@@ -36,20 +39,30 @@ describe('Eth transaction builder send', () => {
       txBuilder.source(testData.KEYPAIR_PRV.getAddress());
       txBuilder.counter(2);
       txBuilder.type(TransactionType.Send);
-      txBuilder.contract('0x8f977e912ef500548a0c3be6ddde9899f1199b81');
+      txBuilder.contract(contractAddress);
     });
 
     it('a send funds transaction', async () => {
+      const recipient = '0x19645032c7f1533395d44a629462e751084d3e4c';
+      const amount = '1000000000';
       txBuilder
         .transfer()
-        .amount('1000000000')
-        .to('0x19645032c7f1533395d44a629462e751084d3e4c')
+        .amount(amount)
+        .to(recipient)
         .expirationTime(1590066728)
         .contractSequenceId(5)
         .key(key);
       txBuilder.sign({ key: testData.PRIVATE_KEY });
       const tx = await txBuilder.build();
       should.equal(tx.toBroadcastFormat(), testData.SEND_TX_BROADCAST);
+      should.equal(tx.signature.length, 2);
+      should.equal(tx.inputs.length, 1);
+      should.equal(tx.inputs[0].address, contractAddress);
+      should.equal(tx.inputs[0].value, amount);
+
+      should.equal(tx.outputs.length, 1);
+      should.equal(tx.outputs[0].address, recipient);
+      should.equal(tx.outputs[0].value, amount);
     });
 
     it('a send funds with amount 0 transaction', async () => {


### PR DESCRIPTION
This commit adds the inputs, outputs, and signatures fields for send
transactions. It parses the transaction data to get these fields, and
exposes them through the same interface that other coins use. This will
help dependent libraries to properly decode transactions and understand
what is happening

Ticket: BG-22118