### PR TITLE
Bump version to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/account-lib",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/account-lib",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "BitGo's account library functions",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
This commit bumps the Bitgo-account-lib version to v1.5.0 to include new
fixes for CGLD

Ticket: BG-22185