### PR TITLE
Bump to 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/account-lib",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/account-lib",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "BitGo's account library functions",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
This commit bumps bitgo-account-lib to 1.6.0 to include

Ticket: BG-22229