### PR TITLE
Bump to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/account-lib",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/account-lib",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "BitGo's account library functions",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
This commit bumps bitgo-account-lib package to 1.7.0 to include new
features and fixes

Ticket: BG-22445