### PR TITLE
Fix crypto deprecation warnings caused by __importStar

### DIFF
--- a/src/coin/trx/keyPair.ts
+++ b/src/coin/trx/keyPair.ts
@@ -1,4 +1,4 @@
-import * as crypto from 'crypto';
+import { randomBytes } from 'crypto';
 import { HDNode } from 'bitgo-utxo-lib';
 import { DefaultKeys } from '../baseCoin/iface';
 import { AddressFormat } from '../baseCoin/enum';
@@ -21,7 +21,7 @@ export class KeyPair extends ExtendedKeyPair {
   constructor(source?: KeyPairOptions) {
     super(source);
     if (!source) {
-      const seed = crypto.randomBytes(DEFAULT_SEED_SIZE_BYTES);
+      const seed = randomBytes(DEFAULT_SEED_SIZE_BYTES);
       this.hdNode = HDNode.fromSeedBuffer(seed);
     } else if (isSeed(source)) {
       this.hdNode = HDNode.fromSeedBuffer(source.seed);

--- a/src/coin/trx/transaction.ts
+++ b/src/coin/trx/transaction.ts
@@ -1,4 +1,4 @@
-import * as crypto from 'crypto';
+import { createHash } from 'crypto';
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
 import BigNumber from 'bignumber.js';
 import { BaseTransaction } from '../baseCoin';
@@ -94,8 +94,7 @@ export class Transaction extends BaseTransaction {
       throw new ParseTransactionError('Empty transaction');
     }
     const hexBuffer = Buffer.from(this._transaction.raw_data_hex, 'hex');
-    const newTxid = crypto
-      .createHash('sha256')
+    const newTxid = createHash('sha256')
       .update(hexBuffer)
       .digest('hex');
     this._transaction.txID = newTxid;

--- a/src/coin/trx/transactionBuilder.ts
+++ b/src/coin/trx/transactionBuilder.ts
@@ -1,4 +1,4 @@
-import * as crypto from 'crypto';
+import { createHash } from 'crypto';
 import * as _ from 'lodash';
 import BigNumber from 'bignumber.js';
 import { BaseCoin as CoinConfig } from '@bitgo/statics';
@@ -163,8 +163,7 @@ export class TransactionBuilder extends BaseTransactionBuilder {
     }
     //Validate the transaction ID from the raw data hex
     const hexBuffer = Buffer.from(currTransaction.raw_data_hex, 'hex');
-    const currTxID = crypto
-      .createHash('sha256')
+    const currTxID = createHash('sha256')
       .update(hexBuffer)
       .digest('hex');
     if (currTransaction.txID !== currTxID) {
@@ -188,8 +187,7 @@ export class TransactionBuilder extends BaseTransactionBuilder {
   // Specifically, checks hex underlying transaction hashes to correct transaction ID.
   validateTransaction(transaction: Transaction): void {
     const hexBuffer = Buffer.from(transaction.toJson().raw_data_hex, 'hex');
-    const txId = crypto
-      .createHash('sha256')
+    const txId = createHash('sha256')
       .update(hexBuffer)
       .digest('hex');
     if (transaction.id !== txId) {

--- a/src/coin/xtz/keyPair.ts
+++ b/src/coin/xtz/keyPair.ts
@@ -1,4 +1,4 @@
-import * as crypto from 'crypto';
+import { randomBytes } from 'crypto';
 import blake2b from 'blake2b';
 import { HDNode, ECPair } from 'bitgo-utxo-lib';
 import { DefaultKeys } from '../baseCoin/iface';
@@ -22,7 +22,7 @@ export class KeyPair extends ExtendedKeyPair {
   constructor(source?: KeyPairOptions) {
     super(source);
     if (!source) {
-      const seed = crypto.randomBytes(DEFAULT_SEED_SIZE_BYTES);
+      const seed = randomBytes(DEFAULT_SEED_SIZE_BYTES);
       this.hdNode = HDNode.fromSeedBuffer(seed);
     } else if (isSeed(source)) {
       this.hdNode = HDNode.fromSeedBuffer(source.seed);


### PR DESCRIPTION
Using `import * as crypto from 'crypto';` imports all fields from the
'crypto' library into the current scope. This includes some deprecated
fields which emit a DeprecationWarning to stdout when the field is
imported, including when using import star. This is discoverable when
running node with the --trace-warnings flag when these warnings are
emitted.

Instead, just import the field desired. This should prevent the
deprecated field from being imported.

Ticket: BG-22502